### PR TITLE
fix(general-types): add plain 10-digit and 13-digit phone numbers to training data (VF-975)

### DIFF
--- a/packages/general-types/src/constants/slot.ts
+++ b/packages/general-types/src/constants/slot.ts
@@ -37,7 +37,7 @@ const EMAIL: SlotTypeValue = {
 const PHONENUMBER: SlotTypeValue = {
   name: SlotType.PHONENUMBER,
   label: 'Phone Number',
-  values: ['1 (800) 642-7676', '123-456-7890', '647 126 3928', '360 392-1293', '906-459-2349'],
+  values: ['1 (800) 642-7676', '123-456-7890', '647 126 3928', '360 392-1293', '906-459-2349', '2018073710', '4791945491'],
 };
 
 export const SlotTypes: ObjectKeys = {


### PR DESCRIPTION
**Fixes or implements [VF-975](https://voiceflow.atlassian.net/browse/VF-975?atlOrigin=eyJpIjoiZTJhNDBhOWY4NDJhNGEyODhmMTc5YmM1MjQ3OTYyMDgiLCJwIjoiaiJ9)**

### Brief description. What is this change?

Adds plain 10-digit (`1234567890`, area code + phone number) and 13-digit (`1234568790123`, country code + area code + phone number) phone numbers to the training data array.

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
