### PR TITLE
fix: path trace type (VF-000)

### DIFF
--- a/packages/general-types/src/nodes/types.ts
+++ b/packages/general-types/src/nodes/types.ts
@@ -38,6 +38,7 @@ export interface DataWithMappings {
 
 export enum TraceType {
   END = 'end',
+  PATH = 'path',
   FLOW = 'flow',
   SPEAK = 'speak',
   BLOCK = 'block',

--- a/packages/general-types/src/trace/index.ts
+++ b/packages/general-types/src/trace/index.ts
@@ -3,7 +3,7 @@ import { TraceFrame as FlowTrace } from '@/nodes/flow';
 import { TraceFrame as ChoiceTrace } from '@/nodes/interaction';
 import { TraceFrame as SpeakTrace } from '@/nodes/speak';
 import { TraceFrame as StreamTrace } from '@/nodes/stream';
-import { BaseTraceFrame, TraceType } from '@/nodes/types';
+import { BaseTraceFrame, NodeType, TraceType } from '@/nodes/types';
 import { TraceFrame as VisualTrace } from '@/nodes/visual';
 
 export { TraceFrame as ExitTrace } from '@/nodes/exit';
@@ -19,6 +19,15 @@ export interface DebugTracePayload {
 
 export interface DebugTrace extends BaseTraceFrame<DebugTracePayload> {
   type: TraceType.DEBUG;
+}
+
+export interface PathTracePayload {
+  path: string;
+  node: NodeType;
+}
+
+export interface PathTrace extends BaseTraceFrame<PathTracePayload> {
+  type: TraceType.PATH;
 }
 
 export interface BlockTracePayload {

--- a/packages/general-types/src/trace/index.ts
+++ b/packages/general-types/src/trace/index.ts
@@ -3,7 +3,7 @@ import { TraceFrame as FlowTrace } from '@/nodes/flow';
 import { TraceFrame as ChoiceTrace } from '@/nodes/interaction';
 import { TraceFrame as SpeakTrace } from '@/nodes/speak';
 import { TraceFrame as StreamTrace } from '@/nodes/stream';
-import { BaseTraceFrame, NodeType, TraceType } from '@/nodes/types';
+import { BaseTraceFrame, TraceType } from '@/nodes/types';
 import { TraceFrame as VisualTrace } from '@/nodes/visual';
 
 export { TraceFrame as ExitTrace } from '@/nodes/exit';
@@ -23,7 +23,6 @@ export interface DebugTrace extends BaseTraceFrame<DebugTracePayload> {
 
 export interface PathTracePayload {
   path: string;
-  node: NodeType;
 }
 
 export interface PathTrace extends BaseTraceFrame<PathTracePayload> {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

Versa needed a new trace type for knowing when it goes out an "else" port in the choice block, or how exactly an intent gets handled.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
