### PR TITLE
feat: add frameType to image step data (VF-1109)

### DIFF
--- a/packages/general-types/src/nodes/visual.ts
+++ b/packages/general-types/src/nodes/visual.ts
@@ -20,6 +20,12 @@ export enum VisualType {
   IMAGE = 'image',
 }
 
+export enum FrameType {
+  AUTO = 'AUTO',
+  DEVICE = 'DEVICE',
+  CUSTOM_SIZE = 'CUSTOM_SIZE',
+}
+
 interface BaseStepData {
   visualType: VisualType;
 }
@@ -31,6 +37,7 @@ export interface ImageStepData extends BaseStepData {
   device: Nullable<DeviceType>;
   dimensions: Nullable<Dimensions>;
   canvasVisibility: CanvasVisibility;
+  frameType?: FrameType;
 }
 
 export interface APLStepData extends BaseStepData {


### PR DESCRIPTION
**Fixes or implements VF-1109**

### Brief description. What is this change?
Since we want the header to change on the step depending on image data, there's no way currently to distinguish the custom size and auto.
This makes it cleaner to do this: 
![8d124dad-dbfa-4513-a1ad-ac42809da0d2](https://user-images.githubusercontent.com/19617248/121558497-bcf71280-c9e3-11eb-97c2-52ad35cffd06.gif)


Since in `creator-app` we can set label based 
```Typescript
     label = data.frameType === FrameType.CUSTOM_SIZE ?  'Custom Size' : 'Auto Fit';
```