### PR TITLE
feat: change `None` intent option to `Fallback` (VF-1111)

### DIFF
--- a/packages/general-types/src/constants/intent.ts
+++ b/packages/general-types/src/constants/intent.ts
@@ -12,7 +12,7 @@ export enum IntentName {
   REPEAT = 'VF.REPEAT',
   PREVIOUS = 'VF.PREVIOUS',
   START_OVER = 'VF.START_OVER',
-  FALLBACK = 'Fallback',
+  FALLBACK = 'VF.FALLBACK',
 }
 
 export interface DefaultIntent {

--- a/packages/general-types/src/constants/intent.ts
+++ b/packages/general-types/src/constants/intent.ts
@@ -12,7 +12,7 @@ export enum IntentName {
   REPEAT = 'VF.REPEAT',
   PREVIOUS = 'VF.PREVIOUS',
   START_OVER = 'VF.START_OVER',
-  FALLBACK = 'VF.FALLBACK',
+  NONE = 'VF.FALLBACK',
 }
 
 export interface DefaultIntent {
@@ -68,7 +68,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['start over', 'restart'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],
@@ -129,7 +129,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['recommencer', 'redémarrer'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],
@@ -196,7 +196,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['最初からやり直す', '再起動'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],
@@ -265,7 +265,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['ricominciare', 'ricomincia'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],
@@ -328,7 +328,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['reiniciar'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],
@@ -450,7 +450,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['recomeçar', 'reiniciar'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],
@@ -562,7 +562,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['प्रारंभ करें', 'पुनर्प्रारंभ करें'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],

--- a/packages/general-types/src/constants/intent.ts
+++ b/packages/general-types/src/constants/intent.ts
@@ -398,7 +398,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['Von vorn anfangen', 'Neustart', 'wieder starten'],
     },
     {
-      name: IntentName.FALLBACK,
+      name: IntentName.NONE,
       samples: [],
     },
   ],

--- a/packages/general-types/src/constants/intent.ts
+++ b/packages/general-types/src/constants/intent.ts
@@ -12,7 +12,7 @@ export enum IntentName {
   REPEAT = 'VF.REPEAT',
   PREVIOUS = 'VF.PREVIOUS',
   START_OVER = 'VF.START_OVER',
-  NONE = 'None',
+  FALLBACK = 'Fallback',
 }
 
 export interface DefaultIntent {
@@ -68,7 +68,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['start over', 'restart'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],
@@ -129,7 +129,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['recommencer', 'redémarrer'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],
@@ -196,7 +196,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['最初からやり直す', '再起動'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],
@@ -265,7 +265,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['ricominciare', 'ricomincia'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],
@@ -328,7 +328,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['reiniciar'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],
@@ -398,7 +398,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['Von vorn anfangen', 'Neustart', 'wieder starten'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],
@@ -450,7 +450,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['recomeçar', 'reiniciar'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],
@@ -562,7 +562,7 @@ export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
       samples: ['प्रारंभ करें', 'पुनर्प्रारंभ करें'],
     },
     {
-      name: IntentName.NONE,
+      name: IntentName.FALLBACK,
       samples: [],
     },
   ],


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1111**

### Brief description. What is this change?
Change builtin `None` in `IntentName` options to `Fallback`, also now recognized as a `isBuiltIn` so that it acts the same as the other built in intents. Tested on alexa and general project types.
![image](https://user-images.githubusercontent.com/19617248/121747013-b8f6ed80-cad4-11eb-8fa2-5b191086de9f.png)
