### PR TITLE
fix: use `readonly T[]` instead of `T[]` when possible (VF-000)

### DIFF
--- a/packages/alexa-types/src/utils/invocationName.ts
+++ b/packages/alexa-types/src/utils/invocationName.ts
@@ -5,9 +5,9 @@ const LAUNCH_PHRASES = ['launch', 'ask', 'tell', 'load', 'begin', 'enable'];
 
 const NON_LATIN_REGIONS = ['ja-JP', 'hi-IN'];
 
-const matchesKeyword = (splitName: string[]) => (keyword: string) => splitName.find((split) => split === keyword.toLowerCase());
+const matchesKeyword = (splitName: readonly string[]) => (keyword: string) => splitName.find((split) => split === keyword.toLowerCase());
 
-export const getInvocationNameError = (name?: string, locales: string[] = []) => {
+export const getInvocationNameError = (name?: string, locales: readonly string[] = []) => {
   if (!name?.trim()) {
     return 'Invocation name required for Alexa';
   }

--- a/packages/api-sdk/src/resources/base.ts
+++ b/packages/api-sdk/src/resources/base.ts
@@ -49,7 +49,7 @@ class BaseResource<S extends BaseSchema, K extends keyof SchemeType<S>, C extend
   }
 
   // eslint-disable-next-line class-methods-use-this
-  protected _getFieldsQuery(fields?: string[]): string {
+  protected _getFieldsQuery(fields?: readonly string[]): string {
     return fields ? `?fields=${fields.join(',')}` : '';
   }
 

--- a/packages/api-sdk/src/resources/crud.ts
+++ b/packages/api-sdk/src/resources/crud.ts
@@ -12,21 +12,21 @@ class CrudResource<
     return id ? `${this._getEndpoint()}/${id}` : this._getEndpoint();
   }
 
-  protected async _get<T extends Partial<SchemeType<S>>>(fields: string[]): Promise<T[]>;
+  protected async _get<T extends Partial<SchemeType<S>>>(fields: readonly string[]): Promise<T[]>;
 
   protected async _get<T extends SchemeType<S>>(): Promise<T[]>;
 
-  protected async _get<T extends SchemeType<S>>(fields?: string[]) {
+  protected async _get<T extends SchemeType<S>>(fields?: readonly string[]) {
     const { data } = await this.fetch.get<T[]>(`${this._getCRUDEndpoint()}${this._getFieldsQuery(fields)}`);
 
     return data;
   }
 
-  protected async _getByID<T extends Partial<SchemeType<S>>>(id: SchemeType<S>[K], fields: string[]): Promise<T>;
+  protected async _getByID<T extends Partial<SchemeType<S>>>(id: SchemeType<S>[K], fields: readonly string[]): Promise<T>;
 
   protected async _getByID<T extends SchemeType<S>>(id: SchemeType<S>[K]): Promise<T>;
 
-  protected async _getByID(id: SchemeType<S>[K], fields?: string[]) {
+  protected async _getByID(id: SchemeType<S>[K], fields?: readonly string[]) {
     this._assertModelID(id);
 
     const { data } = await this.fetch.get(`${this._getCRUDEndpoint(id)}${this._getFieldsQuery(fields)}`);

--- a/packages/api-sdk/src/resources/diagram.ts
+++ b/packages/api-sdk/src/resources/diagram.ts
@@ -24,11 +24,11 @@ class DiagramResource extends CrudResource<typeof SDiagram['schema'], ModelIDKey
     });
   }
 
-  public async get<T extends Partial<Diagram>>(id: DiagramID, fields: string[]): Promise<T>;
+  public async get<T extends Partial<Diagram>>(id: DiagramID, fields: readonly string[]): Promise<T>;
 
   public async get<T extends BaseDiagramNode = BaseDiagramNode>(id: DiagramID): Promise<Diagram<T>>;
 
-  public async get(id: DiagramID, fields?: string[]) {
+  public async get(id: DiagramID, fields?: readonly string[]) {
     return fields ? super._getByID(id, fields) : super._getByID(id);
   }
 

--- a/packages/api-sdk/src/resources/program.ts
+++ b/packages/api-sdk/src/resources/program.ts
@@ -19,11 +19,11 @@ class ProgramResource extends CrudResource<typeof SProgram['schema'], ModelIDKey
     });
   }
 
-  public async get<T extends Partial<Program>>(id: ProgramID, fields: string[]): Promise<T>;
+  public async get<T extends Partial<Program>>(id: ProgramID, fields: readonly string[]): Promise<T>;
 
   public async get<T extends BaseNode, C extends BaseCommand>(id: ProgramID): Promise<Program<T, C>>;
 
-  public async get(id: ProgramID, fields?: string[]) {
+  public async get(id: ProgramID, fields?: readonly string[]) {
     return fields ? super._getByID<Program>(id, fields) : super._getByID<Program>(id);
   }
 

--- a/packages/api-sdk/src/resources/project/index.ts
+++ b/packages/api-sdk/src/resources/project/index.ts
@@ -26,11 +26,14 @@ class ProjectResource extends CrudResource<typeof SProject['schema'], ModelIDKey
     this.member = new MemberResource(fetch);
   }
 
-  public async list<P extends Partial<Project<BasePlatformData, BasePlatformData>>>(workspaceID: WorkspaceID, fields: string[]): Promise<P[]>;
+  public async list<P extends Partial<Project<BasePlatformData, BasePlatformData>>>(
+    workspaceID: WorkspaceID,
+    fields: readonly string[]
+  ): Promise<P[]>;
 
   public async list<P extends BasePlatformData, M extends BasePlatformData>(workspaceID: WorkspaceID): Promise<Project<P, M>[]>;
 
-  public async list(workspaceID: WorkspaceID, fields?: string[]) {
+  public async list(workspaceID: WorkspaceID, fields?: readonly string[]) {
     s.assert(workspaceID, SWorkspaceID);
 
     const { data } = await this.fetch.get(`workspaces/${workspaceID}/projects${this._getFieldsQuery(fields)}`);
@@ -38,11 +41,11 @@ class ProjectResource extends CrudResource<typeof SProject['schema'], ModelIDKey
     return data;
   }
 
-  public async get<P extends Partial<Project<BasePlatformData, BasePlatformData>>>(id: ProjectID, fields: string[]): Promise<P>;
+  public async get<P extends Partial<Project<BasePlatformData, BasePlatformData>>>(id: ProjectID, fields: readonly string[]): Promise<P>;
 
   public async get<P extends BasePlatformData, M extends BasePlatformData>(id: ProjectID): Promise<Project<P, M>>;
 
-  public async get(id: ProjectID, fields?: string[]) {
+  public async get(id: ProjectID, fields?: readonly string[]) {
     return fields ? super._getByID(id, fields) : super._getByID(id);
   }
 
@@ -72,11 +75,11 @@ class ProjectResource extends CrudResource<typeof SProject['schema'], ModelIDKey
     return data;
   }
 
-  public async getVersions<P extends Partial<Version<VersionPlatformData>>>(id: ProjectID, fields: string[]): Promise<P[]>;
+  public async getVersions<P extends Partial<Version<VersionPlatformData>>>(id: ProjectID, fields: readonly string[]): Promise<P[]>;
 
   public async getVersions<P extends VersionPlatformData>(id: ProjectID): Promise<Version<P>[]>;
 
-  public async getVersions(id: ProjectID, fields?: string[]) {
+  public async getVersions(id: ProjectID, fields?: readonly string[]) {
     this._assertModelID(id);
 
     const { data } = await this.fetch.get(`${this._getCRUDEndpoint(id)}/versions${this._getFieldsQuery(fields)}`);

--- a/packages/api-sdk/src/resources/project/member.ts
+++ b/packages/api-sdk/src/resources/project/member.ts
@@ -24,11 +24,11 @@ class MemberResource extends BaseResource<typeof SMember['schema'], ModelIDKey, 
     return `${this._getEndpoint()}/${id}/members`;
   }
 
-  public async list<P extends Partial<Member<BasePlatformData>>>(projectID: ProjectID, fields: string[]): Promise<P[]>;
+  public async list<P extends Partial<Member<BasePlatformData>>>(projectID: ProjectID, fields: readonly string[]): Promise<P[]>;
 
   public async list<P extends BasePlatformData>(projectID: ProjectID): Promise<Member<P>[]>;
 
-  public async list(projectID: ProjectID, fields?: string[]) {
+  public async list(projectID: ProjectID, fields?: readonly string[]) {
     s.assert(projectID, SProjectID);
 
     const { data } = await this.fetch.get(`${this._getCRUDEndpoint(projectID)}${this._getFieldsQuery(fields)}`);
@@ -36,11 +36,11 @@ class MemberResource extends BaseResource<typeof SMember['schema'], ModelIDKey, 
     return data;
   }
 
-  public async get<P extends Partial<Member<BasePlatformData>>>(projectID: ProjectID, fields: string[]): Promise<P>;
+  public async get<P extends Partial<Member<BasePlatformData>>>(projectID: ProjectID, fields: readonly string[]): Promise<P>;
 
   public async get<P extends BasePlatformData>(projectID: ProjectID): Promise<Member<P>>;
 
-  public async get(projectID: ProjectID, fields?: string[]) {
+  public async get(projectID: ProjectID, fields?: readonly string[]) {
     s.assert(projectID, SProjectID);
 
     const { data } = await this.fetch.get(`${this._getEndpoint()}/${projectID}/member${this._getFieldsQuery(fields)}`);

--- a/packages/api-sdk/src/resources/version.ts
+++ b/packages/api-sdk/src/resources/version.ts
@@ -23,11 +23,11 @@ class VersionResource extends CrudResource<typeof SVersion['schema'], ModelKey, 
     });
   }
 
-  public async get<T extends Partial<Version<VersionPlatformData>>>(id: VersionID, fields: string[]): Promise<T>;
+  public async get<T extends Partial<Version<VersionPlatformData>>>(id: VersionID, fields: readonly string[]): Promise<T>;
 
   public async get<P extends VersionPlatformData>(id: VersionID): Promise<Version<P>>;
 
-  public async get(id: VersionID, fields?: string[]) {
+  public async get(id: VersionID, fields?: readonly string[]) {
     return fields ? super._getByID(id, fields) : super._getByID(id);
   }
 
@@ -69,11 +69,11 @@ class VersionResource extends CrudResource<typeof SVersion['schema'], ModelKey, 
     return data;
   }
 
-  public async getPrograms<T extends Partial<Program>>(id: VersionID, fields: string[]): Promise<T[]>;
+  public async getPrograms<T extends Partial<Program>>(id: VersionID, fields: readonly string[]): Promise<T[]>;
 
   public async getPrograms<T extends Program = Program>(id: VersionID): Promise<T[]>;
 
-  public async getPrograms(id: VersionID, fields?: string[]) {
+  public async getPrograms(id: VersionID, fields?: readonly string[]) {
     this._assertModelID(id);
 
     const { data } = await this.fetch.get(`${this._getCRUDEndpoint(id)}/programs${this._getFieldsQuery(fields)}`);
@@ -81,11 +81,11 @@ class VersionResource extends CrudResource<typeof SVersion['schema'], ModelKey, 
     return data;
   }
 
-  public async getPrototypePrograms<T extends Partial<Program>>(id: VersionID, fields: string[]): Promise<T[]>;
+  public async getPrototypePrograms<T extends Partial<Program>>(id: VersionID, fields: readonly string[]): Promise<T[]>;
 
   public async getPrototypePrograms<T extends Program = Program>(id: VersionID): Promise<T[]>;
 
-  public async getPrototypePrograms(id: VersionID, fields?: string[]) {
+  public async getPrototypePrograms(id: VersionID, fields?: readonly string[]) {
     this._assertModelID(id);
 
     const { data } = await this.fetch.get(`${this._getCRUDEndpoint(id)}/prototype-programs${this._getFieldsQuery(fields)}`);
@@ -93,11 +93,11 @@ class VersionResource extends CrudResource<typeof SVersion['schema'], ModelKey, 
     return data;
   }
 
-  public async getDiagrams<T extends Partial<Diagram>>(id: VersionID, fields: string[]): Promise<T[]>;
+  public async getDiagrams<T extends Partial<Diagram>>(id: VersionID, fields: readonly string[]): Promise<T[]>;
 
   public async getDiagrams<T extends Diagram = Diagram>(id: VersionID): Promise<T[]>;
 
-  public async getDiagrams(id: VersionID, fields?: string[]) {
+  public async getDiagrams(id: VersionID, fields?: readonly string[]) {
     this._assertModelID(id);
 
     const { data } = await this.fetch.get(`${this._getCRUDEndpoint(id)}/diagrams${this._getFieldsQuery(fields)}`);

--- a/packages/google-types/src/utils/invocationName.ts
+++ b/packages/google-types/src/utils/invocationName.ts
@@ -5,9 +5,9 @@ const RESERVED_PHRASES = ['exit quit', 'volume up'];
 
 const NON_LATIN_REGIONS = ['ja-JP', 'hi-IN'];
 
-const matchesKeyword = (splitName: string[]) => (keyword: string) => splitName.find((split) => split === keyword.toLowerCase());
+const matchesKeyword = (splitName: readonly string[]) => (keyword: string) => splitName.find((split) => split === keyword.toLowerCase());
 
-export const getInvocationNameError = (name?: string, locales: string[] = []) => {
+export const getInvocationNameError = (name?: string, locales: readonly string[] = []) => {
   if (!name?.trim()) {
     return 'Invocation name required for Google';
   }


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

Many functions are using the `string[]` type when they could be using `readonly string[]`.
Using the readonly version is preferred because you can pass tuples (ex. `['hello'] as const`) to the function, as well as mutable arrays (ex. `['hello']`)

### Implementation details. How do you make this change?

I changed all occurrences of `: string[]` to `: readonly string[]` in relevant functions.
There are probably functions that could use a readonly array but I only modified the `string[]` ones.

### Deployment Notes

A `readonly string[]` is not the same as a `string[]`.
Upgrading to a new version of one of the modified packages might start causing type errors because TypeScript expected a mutable array but received a readonly one.
You can fix these by either changing the type to `readonly string[]` or by undoing the change I made here if something truly needs a mutable array. 

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
