### PR TITLE
fix(api-sdk): only publish build folder (VF-483)

### DIFF
--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -27,6 +27,9 @@
     "ts-mocha": "^7.0.0",
     "tsconfig-paths": "^3.9.0"
   },
+  "files": [
+    "build/"
+  ],
   "homepage": "https://github.com/voiceflow/libs#readme",
   "keywords": [
     "voiceflow"


### PR DESCRIPTION
**Fixes or implements VF-483**

### Brief description. What is this change?

Only publish the `build/` folder and other required files to npm.

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| https://github.com/voiceflow/common/pull/46 | [link](https://github.com/voiceflow/common/pull/46) |
| https://github.com/voiceflow/logger/pull/23     | [link](https://github.com/voiceflow/logger/pull/23) |
| https://github.com/voiceflow/libs/pull/25     | [link](https://github.com/voiceflow/libs/pull/25) |
| https://github.com/voiceflow/general-runtime/pull/137     | [link](https://github.com/voiceflow/general-runtime/pull/137) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
