### PR TITLE
fix(api-sdk): handle bad input to `parseJWT` function (VF-000)

### DIFF
--- a/packages/api-sdk/src/resources/user.ts
+++ b/packages/api-sdk/src/resources/user.ts
@@ -5,6 +5,11 @@ import { getWindow } from '@/utils';
 
 export const parseJWT = <S>(token: string): S => {
   const base64Url = token.split('.')[1];
+
+  if (!base64Url) {
+    throw new RangeError('Invalid JWT');
+  }
+
   const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
   const jsonPayload = decodeURIComponent(
     (getWindow()?.atob || atob)(base64)


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

Stop assuming that tokens are in the proper format, otherwise you get these errors:

![screenshot of error in console](https://user-images.githubusercontent.com/7608555/129430440-789329c5-b424-4170-8436-c5ba805e062c.png)

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
