### PR TITLE
feat: creates no match base interface and adds to ifv2 (VF-1253)

### DIFF
--- a/packages/base-types/src/node/buttons.ts
+++ b/packages/base-types/src/node/buttons.ts
@@ -2,7 +2,7 @@ import { Nullable } from '@voiceflow/api-sdk';
 
 import { StepButtonsLayout } from '../button';
 import { NodeType } from './constants';
-import { BaseStep, BaseStepNoMatches, DataID } from './utils';
+import { BaseStep, BaseStepNoMatch, DataID } from './utils';
 
 export enum ButtonAction {
   URL = 'URL',
@@ -18,7 +18,7 @@ export interface Button extends DataID {
 }
 
 export interface StepData extends StepButtonsLayout {
-  else: BaseStepNoMatches;
+  else: BaseStepNoMatch;
   buttons: Button[];
 }
 

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -1,7 +1,7 @@
 import { AnyRequestButton } from '@/request';
 
 import { NodeType } from './constants';
-import { BaseEvent, BaseNode, BaseNodeNoMatch, BaseStep, BaseStepNoMatches, BaseTraceFrame, NodeNextID, SlotMappings, TraceType } from './utils';
+import { BaseEvent, BaseNode, BaseNodeNoMatch, BaseStep, BaseStepNoMatch, BaseTraceFrame, NodeNextID, SlotMappings, TraceType } from './utils';
 
 export interface Choice extends SlotMappings {
   intent: string;
@@ -9,7 +9,7 @@ export interface Choice extends SlotMappings {
 
 export interface StepData {
   name: string;
-  else: BaseStepNoMatches;
+  else: BaseStepNoMatch;
   choices: Choice[];
 }
 

--- a/packages/base-types/src/node/prompt.ts
+++ b/packages/base-types/src/node/prompt.ts
@@ -1,8 +1,8 @@
 import { NodeType } from './constants';
-import { BaseStep, BaseStepNoMatches } from './utils';
+import { BaseStep, BaseStepNoMatch } from './utils';
 
 export interface StepData {
-  noMatches: BaseStepNoMatches;
+  noMatches: BaseStepNoMatch;
 }
 
 export interface Step<Data = StepData> extends BaseStep<Data, []> {

--- a/packages/base-types/src/node/utils/noMatch.ts
+++ b/packages/base-types/src/node/utils/noMatch.ts
@@ -13,12 +13,9 @@ export interface BaseStepNoMatch {
   pathName?: string;
 }
 
-export interface BaseStepNoMatches extends BaseStepNoMatch {
-  randomize?: boolean;
-}
-
-export interface StepNoMatch<Prompt> extends BaseStepNoMatches {
+export interface StepNoMatch<Prompt> extends BaseStepNoMatch {
   reprompts: Prompt[];
+  randomize?: boolean;
 }
 
 export interface BaseNodeNoMatch {


### PR DESCRIPTION
**Fixes or implements VF-1253**

### Brief description. What is this change?
We need to be able to edit the no match pathname in conditions step and for that we don't need the revision and reprompt attributes.

### Implementation details. How do you make this change?
- We're changing the base no match interface and extending that for the other interfaces implement those additional attributes.
- Adding the new base no match interface to ifv2 base type.