### PR TITLE
feat: adds export project version responses api method (VF-1856)

### DIFF
--- a/packages/api-sdk/src/models/version.ts
+++ b/packages/api-sdk/src/models/version.ts
@@ -140,3 +140,11 @@ export interface Version<P extends VersionPlatformData, C extends BaseCommand = 
   prototype?: VersionPrototype<C, L>;
   platformData: P;
 }
+
+export interface VersionDiagramResponce {
+  id: string;
+  type: string;
+  flow: string;
+  step: string;
+  content: string;
+}

--- a/packages/api-sdk/src/resources/version.ts
+++ b/packages/api-sdk/src/resources/version.ts
@@ -147,6 +147,16 @@ class VersionResource extends CrudResource<typeof SVersion['schema'], ModelKey, 
     return data;
   }
 
+  public async exportResponses(id: VersionID): Promise<{ id: string; type: string; content: string; flow: string; step: string }[]> {
+    this._assertModelID(id);
+
+    const { data } = await this.fetch.get<{ id: string; type: string; content: string; flow: string; step: string }[]>(
+      `${this._getCRUDEndpoint(id)}/export/responses`
+    );
+
+    return data;
+  }
+
   public async import<P extends Project<any, any> = Project<BasePlatformData, BasePlatformData>>(
     workspaceID: string,
     data: { project: P; version: Version<any>; diagrams: Record<string, Diagram<any>> }

--- a/packages/api-sdk/src/resources/version.ts
+++ b/packages/api-sdk/src/resources/version.ts
@@ -1,7 +1,18 @@
 import * as s from 'superstruct';
 
 import Fetch from '@/fetch';
-import { BasePlatformData, Diagram, Program, Project, SVersion, Version, VersionID, VersionPlatformData, VersionPrototype } from '@/models';
+import {
+  BasePlatformData,
+  Diagram,
+  Program,
+  Project,
+  SVersion,
+  Version,
+  VersionDiagramResponce,
+  VersionID,
+  VersionPlatformData,
+  VersionPrototype,
+} from '@/models';
 
 import { Fields } from './base';
 import CrudResource from './crud';
@@ -147,12 +158,10 @@ class VersionResource extends CrudResource<typeof SVersion['schema'], ModelKey, 
     return data;
   }
 
-  public async exportResponses(id: VersionID): Promise<{ id: string; type: string; content: string; flow: string; step: string }[]> {
+  public async exportResponses(id: VersionID): Promise<VersionDiagramResponce[]> {
     this._assertModelID(id);
 
-    const { data } = await this.fetch.get<{ id: string; type: string; content: string; flow: string; step: string }[]>(
-      `${this._getCRUDEndpoint(id)}/export/responses`
-    );
+    const { data } = await this.fetch.get<VersionDiagramResponce[]>(`${this._getCRUDEndpoint(id)}/export/responses`);
 
     return data;
   }


### PR DESCRIPTION
Fixes or implements VF-1856

Brief description. What is this change?
Today we have this feature available on voiceflow desktop app. We want to enable it to our creator-app. So we're creating an endpoint to generate the responses for given versionID diagrams. That response will be use to download a csv file.