### PR TITLE
fix(ci): escape forward slash in regex (VF-1993)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 defaults:
   tag_filters: &tag_filters
     tags:
-      only: /^@voiceflow/.*@[0-9]*(\.[0-9]*)*$/
+      only: /^@voiceflow\/.*@[0-9]*(\.[0-9]*)*$/
 
 workflows:
   generate-config:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1993**

### Brief description. What is this change?

Add backslash to escape forward slash in tag regex.
