### PR TITLE
fix: move model types from api-sdk to base-types (VF-1912)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ sonar/
 nyc_coverage*
 
 .npmrc
+
+.DS_Store

--- a/packages/base-types/src/index.ts
+++ b/packages/base-types/src/index.ts
@@ -1,4 +1,5 @@
 export * as Button from './button';
+export * as Models from './models';
 export * as Node from './node';
 export * as Project from './project';
 export * as Request from './request';

--- a/packages/base-types/src/models/apiKey.ts
+++ b/packages/base-types/src/models/apiKey.ts
@@ -1,0 +1,14 @@
+import { APIKeyID, CreatorID, ProjectID, WorkspaceID } from './shared';
+
+export type APIKey = {
+  _id: APIKeyID;
+
+  workspaceID: WorkspaceID;
+  creatorID: CreatorID;
+  projectID?: ProjectID;
+
+  name: string;
+  permissions: string[];
+  scopes: string[];
+  data?: Record<string, any>;
+};

--- a/packages/base-types/src/models/diagram.ts
+++ b/packages/base-types/src/models/diagram.ts
@@ -1,0 +1,28 @@
+import { BaseDiagramNode, CreatorID, DiagramID, Name, NodeID, Timestamp, Variable, VersionID } from './shared';
+
+export enum DiagramType {
+  TOPIC = 'TOPIC',
+  GROUP = 'GROUP',
+  COMPONENT = 'COMPONENT',
+}
+
+export interface Diagram<N extends BaseDiagramNode = BaseDiagramNode> {
+  _id: DiagramID;
+
+  name: Name;
+  type?: DiagramType;
+  versionID: VersionID;
+  creatorID: CreatorID;
+  variables: Variable[];
+
+  offsetX: number;
+  offsetY: number;
+  zoom: number;
+  intentStepIDs?: string[];
+
+  children: DiagramID[];
+
+  modified: Timestamp;
+
+  nodes: Record<NodeID, N>;
+}

--- a/packages/base-types/src/models/index.ts
+++ b/packages/base-types/src/models/index.ts
@@ -1,0 +1,7 @@
+export * from './apiKey';
+export * from './diagram';
+export * from './member';
+export * from './program';
+export * from './project';
+export * from './shared';
+export * from './version';

--- a/packages/base-types/src/models/member.ts
+++ b/packages/base-types/src/models/member.ts
@@ -1,0 +1,6 @@
+import { CreatorID } from './shared';
+
+export interface Member<P extends Record<string, any> = Record<string, any>> {
+  creatorID: CreatorID;
+  platformData: P;
+}

--- a/packages/base-types/src/models/program.ts
+++ b/packages/base-types/src/models/program.ts
@@ -1,0 +1,11 @@
+import { BaseCommand, BaseNode, NodeID, ProgramID, Variable, VersionID } from './shared';
+
+export interface Program<N extends BaseNode = BaseNode, C extends BaseCommand = BaseCommand> {
+  id: ProgramID;
+  startId: NodeID;
+  skill_id: VersionID; // eslint-disable-line camelcase
+  name?: string;
+  variables: Variable[];
+  lines: Record<NodeID, N>;
+  commands: C[];
+}

--- a/packages/base-types/src/models/project.ts
+++ b/packages/base-types/src/models/project.ts
@@ -1,0 +1,59 @@
+import { Member } from './member';
+import { BasePlatformData, CreatorID, Name, Platform, ProjectID, PrototypeModel, TagID, TeamID, VersionID } from './shared';
+
+export enum ProjectPrototypeNLPType {
+  LUIS = 'LUIS',
+}
+
+export enum ProjectLinkType {
+  CURVED = 'CURVED',
+  STRAIGHT = 'STRAIGHT',
+}
+
+export interface ProjectPrototypeNLPBase {
+  type: string;
+}
+
+export interface ProjectPrototypeLuis extends ProjectPrototypeNLPBase {
+  appID: string;
+  resourceID?: string;
+  type: ProjectPrototypeNLPType.LUIS;
+}
+
+export type ProjectPrototypeNLP = ProjectPrototypeLuis;
+
+export interface ProjectPrototype {
+  data: Record<string, any>;
+  trainedModel?: PrototypeModel;
+  lastTrainedTime?: number;
+  nlp?: ProjectPrototypeNLP;
+}
+
+export enum ProjectPrivacy {
+  PUBLIC = 'public',
+  PRIVATE = 'private',
+}
+
+export type ReportTag = {
+  tagID: TagID;
+  label: string;
+};
+
+export interface Project<P extends BasePlatformData, M extends BasePlatformData> {
+  _id: ProjectID;
+  teamID: TeamID;
+  creatorID: CreatorID;
+
+  name: Name;
+  image?: string;
+  privacy?: ProjectPrivacy.PRIVATE | ProjectPrivacy.PUBLIC;
+  platform: Platform;
+  linkType?: typeof ProjectLinkType;
+  prototype?: ProjectPrototype;
+  devVersion?: VersionID;
+  liveVersion?: VersionID;
+  reportTags?: Record<TagID, ReportTag>;
+
+  members: Member<M>[];
+  platformData: P;
+}

--- a/packages/base-types/src/models/shared.ts
+++ b/packages/base-types/src/models/shared.ts
@@ -1,0 +1,146 @@
+import { AnyRecord, Nullable } from './utils';
+
+export type Platform = string;
+
+export type Name = string;
+
+export type APIKeyID = string;
+
+export type TeamID = string;
+
+// alias for the team id
+export type WorkspaceID = TeamID;
+
+export type BlockID = string;
+
+export type Variable = string;
+
+export type TagID = string;
+
+export type Timestamp = number;
+
+export type ProjectID = string;
+
+export type CreatorID = number;
+
+export type VersionID = string;
+
+export type ProgramID = string;
+
+export type DiagramID = string;
+
+export interface IntentInput {
+  text: string;
+  slots?: string[];
+  /** @deprecated shouldn't be used */
+  voice?: string;
+}
+
+export type IntentSlotDialog = {
+  prompt: any[];
+  confirm: any[];
+  utterances: IntentInput[];
+  confirmEnabled: boolean;
+};
+
+export type IntentSlot = {
+  id: string;
+  dialog: IntentSlotDialog;
+  required: boolean;
+};
+
+export type Intent = {
+  key: string;
+  name: string;
+  slots?: IntentSlot[];
+  inputs: IntentInput[];
+  builtIn: boolean;
+  _platform?: string;
+};
+
+export type Slot = {
+  key: string;
+  name: string;
+  type: {
+    value?: string;
+  };
+  color?: string;
+  inputs: string[];
+};
+
+export type SlotMapping = {
+  slot: Nullable<string>;
+  variable: Nullable<Variable>;
+};
+
+export type CommandMapping = {
+  slot: string;
+  variable: Variable;
+};
+
+/**
+ * @deprecated
+ */
+export type Command<T extends string = string, D extends AnyRecord = AnyRecord> = {
+  type: T;
+} & D;
+export interface BaseCommand {
+  type: string;
+}
+
+export type NodeID = string;
+
+export type NodeType = string;
+
+/**
+ * @deprecated
+ */
+export type Node<T extends string = string, D extends AnyRecord = AnyRecord> = {
+  id: string;
+  type: T;
+} & D;
+
+export interface BaseNode {
+  id: string;
+  type: string;
+}
+
+export type CoordPoint = number;
+
+export interface BaseDiagramNode<D extends AnyRecord = AnyRecord> {
+  nodeID: NodeID;
+  type: NodeType;
+  coords?: [number, number];
+  data: D;
+}
+
+export interface BlockOnlyData {
+  name: string;
+  color: string;
+  steps: string[];
+}
+
+export interface BaseBlock<D extends AnyRecord = AnyRecord> extends BaseDiagramNode<D & BlockOnlyData> {
+  coords: [number, number];
+}
+
+export interface BasePort<PD extends AnyRecord = AnyRecord> {
+  type: string;
+  target: Nullable<string>;
+  data?: PD;
+  id: string;
+}
+
+// [BasePort, ...BasePort[]] means one or more ports
+interface StepOnlyData<P = [BasePort, ...BasePort[]]> {
+  ports: P;
+}
+
+export type BaseStep<D extends AnyRecord = AnyRecord, P = [BasePort, ...BasePort[]]> = BaseDiagramNode<D & StepOnlyData<P>>;
+
+export type BasePlatformData = AnyRecord;
+
+export type PrototypeModel = {
+  slots: Slot[];
+  intents: Intent[];
+};

--- a/packages/base-types/src/models/utils.ts
+++ b/packages/base-types/src/models/utils.ts
@@ -1,0 +1,2 @@
+export type Nullable<T> = T | null;
+export type AnyRecord = Record<string, any>;

--- a/packages/base-types/src/models/version.ts
+++ b/packages/base-types/src/models/version.ts
@@ -1,0 +1,93 @@
+import { BaseCommand, CreatorID, DiagramID, Intent, Name, Platform, ProjectID, PrototypeModel, Slot, Variable, VersionID } from './shared';
+import { AnyRecord, Nullable } from './utils';
+
+export type VersionPlatformDataSettings = Record<string, any>;
+
+export type VersionPlatformDataPublishing = Record<string, any>;
+
+export interface StrictVersionPlatformData<S extends AnyRecord = AnyRecord, P extends AnyRecord = AnyRecord> {
+  slots: Slot[];
+  intents: Intent[];
+  settings: S;
+  publishing: P;
+}
+
+export interface VersionPlatformData<S extends AnyRecord = AnyRecord, P extends AnyRecord = AnyRecord>
+  extends StrictVersionPlatformData<S, P>,
+    AnyRecord {}
+
+export interface VersionPrototypeStackFrame<C extends BaseCommand = BaseCommand> {
+  nodeID?: Nullable<string>;
+  programID: string;
+  storage?: Record<string, any>;
+  variables?: Record<string, any>;
+  commands?: C[];
+}
+
+export interface VersionPrototypeContext<C extends BaseCommand = BaseCommand> {
+  turn?: Record<string, any>;
+  storage?: Record<string, any>;
+  variables?: Record<string, any>;
+  stack?: VersionPrototypeStackFrame<C>[];
+}
+
+export interface VersionPrototypeData<L extends string> {
+  name: string;
+  locales: L[];
+}
+
+export type VersionPrototypeSettings = {
+  layout?: string;
+  brandColor?: string;
+  brandImage?: string;
+  avatar?: string;
+  password?: string;
+  hasPassword?: boolean;
+  buttons?: string;
+};
+
+export interface VersionPrototype<C extends BaseCommand = BaseCommand, L extends string = string> {
+  model: PrototypeModel;
+  platform: Platform;
+  settings: VersionPrototypeSettings;
+  data: VersionPrototypeData<L>;
+  context: VersionPrototypeContext<C>;
+}
+
+export enum VersionFolderItemType {
+  FOLDER = 'FOLDER',
+  DIAGRAM = 'DIAGRAM',
+}
+
+export interface VersionFolderItem {
+  type: VersionFolderItemType;
+  sourceID: string;
+}
+
+export interface VersionFolder {
+  id: string;
+  name: string;
+  items: VersionFolderItem[];
+}
+
+export interface Version<P extends VersionPlatformData, C extends BaseCommand = BaseCommand, L extends string = string> {
+  _id: VersionID;
+  creatorID: CreatorID;
+  projectID: ProjectID;
+  name: Name;
+  topics?: VersionFolderItem[];
+  folders?: Record<string, VersionFolder>;
+  variables: Variable[];
+  components?: VersionFolderItem[];
+  rootDiagramID: DiagramID;
+  prototype?: VersionPrototype<C, L>;
+  platformData: P;
+}
+
+export interface VersionDiagramResponce {
+  id: string;
+  type: string;
+  flow: string;
+  step: string;
+  content: string;
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
 sonar.projectKey=voiceflow_libs
 sonar.organization=voiceflow
 sonar.modules=packages/api-sdk,packages/alexa-types,packages/google-types,packages/general-types,packages/base-types,packages/voice-types,packages/chat-types
+sonar.cpd.exclusions=packages/base-types/src/models/*


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1912**

### Brief description. What is this change?

Move the model types from api-sdk to base-types and converting the types from being defined by superstructs to regular TS.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
