### PR TITLE
feat: add triggerPhrase property to publishing for dfes (VF-2032)

### DIFF
--- a/packages/google-dfes-types/src/version/publishing.ts
+++ b/packages/google-dfes-types/src/version/publishing.ts
@@ -4,12 +4,12 @@ import { Locale } from '@/constants';
 
 export interface GoogleDFESVersionPublishing extends Version.BaseGoogleVersionPublishing {
   locales: Locale[];
-  triggerPhrase?: string;
+  triggerPhrase?: string[];
 }
 
 export const defaultGoogleDFESVersionPublishing = ({
   locales = [],
-  triggerPhrase,
+  triggerPhrase = [],
   ...baseGoogleVersionPublising
 }: Partial<GoogleDFESVersionPublishing> = {}): GoogleDFESVersionPublishing => ({
   ...Version.defaultBaseGoogleVersionPublishing(baseGoogleVersionPublising),


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2032**

### Brief description. What is this change?

Added `triggerPhrase` property to `GoogleDFESVersionPublishing`