### PR TITLE
ci: skip rebase on drafts (VF-2100)

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -2,11 +2,12 @@
 name: Automatic Rebase
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   rebase-to-master:
     name: Rebase to Master
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Part or VF-2100**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

This skips the rebase job when the current PR is a draft.


### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded

