### PR TITLE
fix: eng default alexa voice (VF-2090)

### DIFF
--- a/packages/alexa-types/src/constants/base.ts
+++ b/packages/alexa-types/src/constants/base.ts
@@ -67,10 +67,10 @@ export enum Voice {
 export const DEFAULT_LOCALE_VOICE_MAP = {
   [Locale.DE_DE]: Voice.MARLENE,
   [Locale.EN_AU]: Voice.NICOLE,
-  [Locale.EN_CA]: Voice.JOANNA,
+  [Locale.EN_CA]: Voice.ALEXA,
   [Locale.EN_GB]: Voice.AMY,
   [Locale.EN_IN]: Voice.ADITI,
-  [Locale.EN_US]: Voice.JOANNA,
+  [Locale.EN_US]: Voice.ALEXA,
   [Locale.ES_ES]: Voice.CONCHITA,
   [Locale.ES_MX]: Voice.MIA,
   [Locale.ES_US]: Voice.PENELOPE,


### PR DESCRIPTION
Joanna to Alexa, (which is actually the same, but I guess Alexa is more known as the name, "Alexa" doesnt actually exist)