### PR TITLE
fix: deprecate `ArrayElement` (VF-000)

### DIFF
--- a/packages/api-sdk/src/types.ts
+++ b/packages/api-sdk/src/types.ts
@@ -1,4 +1,5 @@
-export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
+/** @deprecated Use `T[number]` instead of `ArrayElement<T>` */
+export type ArrayElement<A> = A extends ArrayLike<unknown> ? A[number] : never;
 
 export type BaseSchema = Record<string, any>;
 


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

deprecate usage of the `ArrayElement` type, it should be replace with index type syntax

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
