### PR TITLE
ci: bump orb version to add API trigger for published lerna tags (VF-2167)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -6,7 +6,7 @@ parameters:
     default: false
 
 orbs:
-  vfcommon: voiceflow/common@0.0.246
+  vfcommon: voiceflow/common@0.0.258
   sonarcloud: sonarsource/sonarcloud@1.0.2
 
 jobs:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2167**

### Brief description. What is this change?

Bumps orb version to add API trigger for published lerna tags from https://github.com/voiceflow/orb-common/pull/50

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
