### PR TITLE
feat: export TraceType In Trace (VF-000)

### DIFF
--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -14,8 +14,8 @@ export { TraceFrame as ChoiceTrace } from '@/node/interaction';
 export { TraceFrame as SpeakTrace } from '@/node/speak';
 export { TraceFrame as StreamTrace } from '@/node/stream';
 export { TraceFrame as TextTrace } from '@/node/text';
-export { TraceFrame as VisualTrace } from '@/node/visual';
 export { TraceType } from '@/node/utils/trace';
+export { TraceFrame as VisualTrace } from '@/node/visual';
 
 export interface DebugTracePayload {
   type?: string;

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -15,7 +15,7 @@ export { TraceFrame as SpeakTrace } from '@/node/speak';
 export { TraceFrame as StreamTrace } from '@/node/stream';
 export { TraceFrame as TextTrace } from '@/node/text';
 export { TraceFrame as VisualTrace } from '@/node/visual';
-export { TraceType } from '@/node/trace';
+export { TraceType } from '@/node/utils/trace';
 
 export interface DebugTracePayload {
   type?: string;

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -15,6 +15,7 @@ export { TraceFrame as SpeakTrace } from '@/node/speak';
 export { TraceFrame as StreamTrace } from '@/node/stream';
 export { TraceFrame as TextTrace } from '@/node/text';
 export { TraceFrame as VisualTrace } from '@/node/visual';
+export { TraceType } from '@/node/trace';
 
 export interface DebugTracePayload {
   type?: string;


### PR DESCRIPTION
### Brief description. What is this change?

Export TraceType with the Trace object

### Implementation details. How do you make this change?

We are using TraceType in our code but the import is not exposed to any top level and so we had to import like so:
```typescript
import { TraceType } from '@voiceflow/base-types/build/node/utils'; 
```

This will move it so we can use it like this:
```typescript
import { Trace } from "@voiceflow/base-types";
...
switch(trace.type) {
  case Trace.TraceType.TEXT: 
    ...
    break;
  case Trace.TraceType.SPEAK: 
    ...
    break;
```

**NOTE:** if you have a better way to check a trace's type please let me know!

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
