### PR TITLE
feat: support batch for segment tracking (VF-2464)

### DIFF
--- a/packages/api-sdk/src/resources/analytics.ts
+++ b/packages/api-sdk/src/resources/analytics.ts
@@ -23,22 +23,36 @@ interface IdentifyOptions<T extends Record<string, any>, K extends keyof T> exte
 
 interface AnalyticsOptions {
   encryption?: Crypto.Synchronous;
+  batching?: boolean;
 }
 
 class Analytics extends Fetcher<Analytics, AnalyticsOptions> {
   private encryption?: Crypto.Synchronous;
 
+  private queue: Record<string, unknown>[];
+
+  private batching?: boolean;
+
+  private batchPromise: Promise<void> | null;
+
   constructor(fetch: Fetch, options: AnalyticsOptions = {}) {
     super({ fetch, clazz: Analytics, endpoint: ENDPOINT, clazzOptions: options });
 
     this.encryption = options.encryption;
+    this.queue = [];
+    this.batching = options.batching;
+    this.batchPromise = null;
+  }
+
+  public setBatching(batching: boolean): void {
+    this.batching = batching;
   }
 
   private get shouldEncrypt() {
     return !!this.encryption;
   }
 
-  private encryptedPayload(data: Record<string, unknown>): { message: string } {
+  private encryptedPayload(data: Record<string, unknown> | Record<string, unknown>[]): { message: string } {
     if (!this.encryption) {
       throw new Error('Encryption should be provided!');
     }
@@ -48,6 +62,55 @@ class Analytics extends Fetcher<Analytics, AnalyticsOptions> {
 
   protected _getEndpoint(): string {
     return this.shouldEncrypt ? ENCRYPTED_ENDPOINT : ENDPOINT;
+  }
+
+  private async _enqueue(payload: Record<string, unknown>) {
+    this.queue.push(payload);
+
+    if (this.batchPromise) {
+      return;
+    }
+
+    // we await for Promise.resolve, to push all events that came in the same tick from event loop
+    this.batchPromise = Promise.resolve();
+    await this.batchPromise;
+    this.flushBatched();
+    this.batchPromise = null;
+  }
+
+  public flushBatched(): Promise<void> {
+    const payload = this.queue;
+    this.queue = [];
+
+    let promise: Promise<unknown>;
+
+    // can not have async execution on FE window.addEventListener('beforeunload', ...) process thread
+    if (this.shouldEncrypt) {
+      promise = this.fetch.post(`${this._getEndpoint()}/batch`, this.encryptedPayload(payload));
+    } else {
+      promise = this.fetch.post(`${this._getEndpoint()}/batch-track`, payload);
+    }
+
+    return promise
+      .then(() => undefined)
+      .catch(() => {
+        this.queue.push(...payload);
+      });
+  }
+
+  public batchTrack<P extends Record<string, any>, K extends keyof P>(
+    event: string,
+    { envIDs, hashed, teamhashed, properties = {} as P }: TrackOptions<P, K> = {}
+  ): void {
+    if (!event) {
+      return;
+    }
+
+    if (this.batching) {
+      this._enqueue({ event, envIDs, hashed, teamhashed, properties });
+    } else {
+      this.track(event, { envIDs, hashed, teamhashed, properties });
+    }
   }
 
   public track<P extends Record<string, any>, K extends keyof P>(

--- a/packages/api-sdk/tests/resources/analytics.unit.ts
+++ b/packages/api-sdk/tests/resources/analytics.unit.ts
@@ -83,13 +83,8 @@ describe('Analytics', () => {
     await Promise.resolve();
 
     expect(fetch.post.args).to.eql([
-      [
-        'analytics/batch-track',
-        [
-          { event: 'Event', envIDs: undefined, hashed: undefined, properties: {}, teamhashed: undefined },
-          { event: 'Event 2', hashed: ['id'], properties: { id: 'id', value: 10 }, teamhashed: undefined, envIDs: undefined },
-        ],
-      ],
+      ['analytics/track', { event: 'Event', envIDs: undefined, hashed: undefined, properties: {}, teamhashed: undefined }],
+      ['analytics/track', { event: 'Event 2', hashed: ['id'], properties: { id: 'id', value: 10 }, teamhashed: undefined, envIDs: undefined }],
     ]);
   });
 

--- a/packages/api-sdk/tests/resources/analytics.unit.ts
+++ b/packages/api-sdk/tests/resources/analytics.unit.ts
@@ -74,6 +74,55 @@ describe('Analytics', () => {
     ]);
   });
 
+  it('.batchTrack without batching', async () => {
+    const { fetch, analytics } = createClient();
+
+    analytics.batchTrack('Event');
+    analytics.batchTrack('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
+
+    await Promise.resolve();
+
+    expect(fetch.post.args).to.eql([
+      [
+        'analytics/batch-track',
+        [
+          { event: 'Event', envIDs: undefined, hashed: undefined, properties: {}, teamhashed: undefined },
+          { event: 'Event 2', hashed: ['id'], properties: { id: 'id', value: 10 }, teamhashed: undefined, envIDs: undefined },
+        ],
+      ],
+    ]);
+  });
+
+  it('.batchTrack with batching', async () => {
+    const { fetch, analytics } = createClient();
+    analytics.setBatching(true);
+    analytics.batchTrack('Event');
+    analytics.batchTrack('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
+
+    await Promise.resolve();
+
+    expect(fetch.post.args).to.eql([
+      [
+        'analytics/batch-track',
+        [
+          { event: 'Event', envIDs: undefined, hashed: undefined, properties: {}, teamhashed: undefined },
+          { event: 'Event 2', hashed: ['id'], properties: { id: 'id', value: 10 }, teamhashed: undefined, envIDs: undefined },
+        ],
+      ],
+    ]);
+  });
+
+  it('.batchTrack encrypted with batching', async () => {
+    const { fetch, analytics } = createClient(true);
+    analytics.setBatching(true);
+    analytics.batchTrack('Event');
+    analytics.batchTrack('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
+
+    await Promise.resolve();
+
+    expect(fetch.post.args).to.eql([['vf-ping/batch', { message: 'message' }]]);
+  });
+
   it('.identify', async () => {
     const { fetch, analytics } = createClient();
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Implements VF-2464**

### Brief description. What is this change?
Support for batch segment tracking calls for the api.

When using `batchTrack` method, with `batching` option enabled, all calls made in the same tick, will be sent as a single request.

These new endpoints have been implemented on this PR: https://github.com/voiceflow/creator-api/pull/878