### PR TITLE
feat: merge batchTrack and track methods into track (VF-2464)

### DIFF
--- a/packages/api-sdk/src/resources/analytics.ts
+++ b/packages/api-sdk/src/resources/analytics.ts
@@ -64,7 +64,7 @@ class Analytics extends Fetcher<Analytics, AnalyticsOptions> {
     return this.shouldEncrypt ? ENCRYPTED_ENDPOINT : ENDPOINT;
   }
 
-  private async _enqueue(payload: Record<string, unknown>) {
+  private async _enqueue(payload: Record<string, unknown>): Promise<void> {
     this.queue.push(payload);
 
     if (this.batchPromise) {
@@ -101,16 +101,15 @@ class Analytics extends Fetcher<Analytics, AnalyticsOptions> {
   public track<P extends Record<string, any>, K extends keyof P>(
     event: string,
     { envIDs, hashed, teamhashed, properties = {} as P }: TrackOptions<P, K> = {}
-  ): void {
+  ): Promise<void> {
     if (!event) {
-      return;
+      return Promise.resolve();
     }
 
     if (this.batching) {
-      this._enqueue({ event, envIDs, hashed, teamhashed, properties });
-    } else {
-      this._send(event, { envIDs, hashed, teamhashed, properties });
+      return this._enqueue({ event, envIDs, hashed, teamhashed, properties });
     }
+    return this._send(event, { envIDs, hashed, teamhashed, properties });
   }
 
   private _send<P extends Record<string, any>, K extends keyof P>(

--- a/packages/api-sdk/src/resources/analytics.ts
+++ b/packages/api-sdk/src/resources/analytics.ts
@@ -98,7 +98,7 @@ class Analytics extends Fetcher<Analytics, AnalyticsOptions> {
       });
   }
 
-  public batchTrack<P extends Record<string, any>, K extends keyof P>(
+  public track<P extends Record<string, any>, K extends keyof P>(
     event: string,
     { envIDs, hashed, teamhashed, properties = {} as P }: TrackOptions<P, K> = {}
   ): void {
@@ -109,11 +109,11 @@ class Analytics extends Fetcher<Analytics, AnalyticsOptions> {
     if (this.batching) {
       this._enqueue({ event, envIDs, hashed, teamhashed, properties });
     } else {
-      this.track(event, { envIDs, hashed, teamhashed, properties });
+      this._send(event, { envIDs, hashed, teamhashed, properties });
     }
   }
 
-  public track<P extends Record<string, any>, K extends keyof P>(
+  private _send<P extends Record<string, any>, K extends keyof P>(
     event: string,
     { envIDs, hashed, teamhashed, properties = {} as P }: TrackOptions<P, K> = {}
   ): Promise<void> {

--- a/packages/api-sdk/tests/resources/analytics.unit.ts
+++ b/packages/api-sdk/tests/resources/analytics.unit.ts
@@ -74,25 +74,11 @@ describe('Analytics', () => {
     ]);
   });
 
-  it('.batchTrack without batching', async () => {
-    const { fetch, analytics } = createClient();
-
-    analytics.batchTrack('Event');
-    analytics.batchTrack('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
-
-    await Promise.resolve();
-
-    expect(fetch.post.args).to.eql([
-      ['analytics/track', { event: 'Event', envIDs: undefined, hashed: undefined, properties: {}, teamhashed: undefined }],
-      ['analytics/track', { event: 'Event 2', hashed: ['id'], properties: { id: 'id', value: 10 }, teamhashed: undefined, envIDs: undefined }],
-    ]);
-  });
-
-  it('.batchTrack with batching', async () => {
+  it('.track with batching', async () => {
     const { fetch, analytics } = createClient();
     analytics.setBatching(true);
-    analytics.batchTrack('Event');
-    analytics.batchTrack('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
+    analytics.track('Event');
+    analytics.track('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
 
     await Promise.resolve();
 
@@ -107,11 +93,11 @@ describe('Analytics', () => {
     ]);
   });
 
-  it('.batchTrack encrypted with batching', async () => {
+  it('.track encrypted with batching', async () => {
     const { fetch, analytics } = createClient(true);
     analytics.setBatching(true);
-    analytics.batchTrack('Event');
-    analytics.batchTrack('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
+    analytics.track('Event');
+    analytics.track('Event 2', { properties: { id: 'id', value: 10 }, hashed: ['id'] });
 
     await Promise.resolve();
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

It merges `batchTrack` and `track` methods into just `track`. It will batch the request when `batching` is enabled.

This way we don't have refactor all the calls from `.track` to  `.batchTrack`, making it easier to use.

This is a breaking change since .batchTrack will not exist anymore, but since this method was only published a couple weeks ago and we are using in less than 10 places, not sure if we need to publish a major.

### Implementation details. How do you make this change?
renamed `batchTrack` to `track` and original `track` became the private method `_send`.


### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
