### PR TITLE
fix: use stricter type for `MetricsAsserter` constructor (VF-000)

### DIFF
--- a/packages/metrics/src/testing/MetricsAsserter.ts
+++ b/packages/metrics/src/testing/MetricsAsserter.ts
@@ -41,7 +41,7 @@ type TestingConfig = Pick<Config, 'SERVICE_NAME'>;
 const DEFAULT_SERVICE_NAME = `test-${Math.random().toString(36).slice(2)}`;
 
 export class MetricsAsserter<M extends Metrics> {
-  constructor(private readonly MetricsClient: (...args: any[]) => M) {}
+  constructor(private readonly MetricsClient: (config: Config) => M) {}
 
   /**
    * Assert that a metrics endpoint matches a regular expression(s).


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

some services (ex. realtime) don't use the client factory type of `(config: Config) => Client`, they use `(options: { config: Config, logger: Logger })`

this leads to confusing errors during tests, where you get `Error: connect ECONNREFUSED 127.0.0.1:somerandomport`. this is because `options.PORT_METRICS` doesn't matter when the user's code is reading `options.config.PORT_METRICS`.

since the configuration value is missing it falls back to the default port of `9464`.
the server is on `9464` but the assertion tries to use `{some random port}`, which is what causes the `ECONNREFUSED` error

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written