### PR TITLE
fix: improve typings of configs in `MetricsAsserter` (VF-000)

### DIFF
--- a/packages/metrics/src/testing/MetricsAsserter.ts
+++ b/packages/metrics/src/testing/MetricsAsserter.ts
@@ -5,9 +5,9 @@ import { expect } from 'chai';
 import { setTimeout as sleep } from 'timers/promises';
 import types from 'util/types';
 
-import type { Config, Metrics } from '@/client';
+import type { Metrics as BaseMetrics } from '@/client';
 
-import { createBaseConfig } from './createBaseConfig';
+import { BaseConfig, createBaseConfig } from './createBaseConfig';
 
 /**
  * An internal class used to expose the {@link AssertionHelper.assert}
@@ -15,7 +15,7 @@ import { createBaseConfig } from './createBaseConfig';
 class AssertionHelper {
   constructor(
     private readonly options: Readonly<{
-      metrics: Metrics;
+      metrics: BaseMetrics;
       route: string;
       expressions: readonly RegExp[];
     }>
@@ -36,30 +36,24 @@ class AssertionHelper {
   }
 }
 
-type TestingConfig = Pick<Config, 'SERVICE_NAME'>;
-/** Doing this once in module scope is fine since only 1 service will be running tests, there is no realistic risk of collision. */
-const DEFAULT_SERVICE_NAME = `test-${Math.random().toString(36).slice(2)}`;
-
-export class MetricsAsserter<M extends Metrics> {
-  constructor(private readonly MetricsClient: (config: Config) => M) {}
+export class MetricsAsserter<Metrics extends BaseMetrics, Config extends Record<never, never>> {
+  constructor(private readonly MetricsClient: (config: Config & BaseConfig) => Metrics) {}
 
   /**
    * Assert that a metrics endpoint matches a regular expression(s).
    */
   async assertMetric({
     /** The config to use in the metrics client. */
-    config = {
-      SERVICE_NAME: DEFAULT_SERVICE_NAME,
-    },
+    config = {},
     /** The regular expression(s) to match against the metrics output. */
     expected,
   }: {
-    config?: TestingConfig;
+    config?: Partial<Config>;
     expected: RegExp | ReadonlyArray<RegExp>;
-  }): Promise<{ metrics: M; assert: () => Promise<void> }> {
+  }): Promise<{ metrics: Metrics; assert: () => Promise<void> }> {
     const combinedConfig = { ...(await createBaseConfig()), ...config };
 
-    const metrics = this.MetricsClient(combinedConfig);
+    const metrics = this.MetricsClient(combinedConfig as unknown as Config & BaseConfig);
 
     const expressions = types.isRegExp(expected) ? [expected] : expected;
 

--- a/packages/metrics/src/testing/createBaseConfig.ts
+++ b/packages/metrics/src/testing/createBaseConfig.ts
@@ -1,10 +1,20 @@
 import getPort from 'get-port';
 
+export interface BaseConfig {
+  PORT_METRICS: string;
+  NODE_ENV: 'test';
+  SERVICE_NAME: string;
+}
+
+/** Doing this once in module scope is fine since only 1 service will be running tests, there is no realistic risk of collision. */
+const DEFAULT_SERVICE_NAME = `test-${Math.random().toString(36).slice(2)}`;
+
 /**
  * Create a base config for the metrics class with a random free port & a `test` `NODE_ENV`.
  * @returns A base config object for the metrics class
  */
-export const createBaseConfig = async (): Promise<{ PORT_METRICS: string; NODE_ENV: 'test' }> => ({
+export const createBaseConfig = async (): Promise<BaseConfig> => ({
   PORT_METRICS: (await getPort()).toString(),
   NODE_ENV: 'test',
+  SERVICE_NAME: DEFAULT_SERVICE_NAME,
 });


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

improves the typings in `MetricsAsserter` so that users of the library never need to use type assertions when writing their unit tests.
this also includes some refactors to how the base config is used

now this is possible:

```ts
import * as VFMetrics from '@voiceflow/metrics';

import CustomMetricsClient, { CustomMetrics } from '@/lib/clients/metrics';
import { CustomConfig } from '@/types';

const metricsAsserter = new VFMetrics.Testing.MetricsAsserter<CustomMetrics, CustomConfig>((config) => CustomMetricsClient({ someCustomKey: config }));
```

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
