### PR TITLE
fix: getProto return data type update (VF-000)

### DIFF
--- a/packages/base-types/src/models/version.ts
+++ b/packages/base-types/src/models/version.ts
@@ -34,6 +34,9 @@ export interface VersionPrototypeContext<C extends BaseCommand = BaseCommand> {
 export interface VersionPrototypeData<L extends string> {
   name: string;
   locales: L[];
+  messageDelay?: {
+    durationMilliseconds: number;
+  };
 }
 
 export interface VersionPrototypeSettings {


### PR DESCRIPTION
need to add this, cause public getPrototype can now return this new data in it's version data