### PR TITLE
feat: add `hex2abc` function (VF-000)

### DIFF
--- a/packages/common/src/crypto/hex2abc.ts
+++ b/packages/common/src/crypto/hex2abc.ts
@@ -1,0 +1,29 @@
+const mapping = {
+  a: 'a',
+  b: 'b',
+  c: 'c',
+  d: 'd',
+  e: 'e',
+  f: 'f',
+  0: 'g',
+  1: 'h',
+  2: 'i',
+  3: 'j',
+  4: 'k',
+  5: 'l',
+  6: 'm',
+  7: 'n',
+  8: 'o',
+  9: 'p',
+
+  // Just in case someone passes a string like 0xabc
+  x: 'x',
+} as const;
+
+/**
+ * Turns a hexadecimal string into lowercase alphabetical characters.
+ *
+ * @param hex - The hexadecimal string to convert
+ * @returns A string of lowercase alphabetical characters
+ */
+export const hex2abc = (hex: string): string => Array.prototype.map.call(hex.toLowerCase(), (char) => mapping[char as keyof typeof mapping]).join('');

--- a/packages/common/tests/crypto/hex2abc.ts
+++ b/packages/common/tests/crypto/hex2abc.ts
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+
+import { hex2abc } from '@/crypto/hex2abc';
+
+describe('hex2abc()', () => {
+  it('works', () => {
+    expect(hex2abc('abcdef')).to.eql('abcdef');
+
+    expect(hex2abc('0123456789')).to.eql('ghijklmnop');
+  });
+  it('works with 0x prefixes', () => {
+    expect(hex2abc('0xabc123')).to.eql('gxabchij');
+  });
+});


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

`hex2abc('0xabc123')` becomes `gxabchij`

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written