### PR TITLE
fix: entity filling trace (VF-2728)

### DIFF
--- a/packages/base-types/src/node/utils/trace.ts
+++ b/packages/base-types/src/node/utils/trace.ts
@@ -13,6 +13,7 @@ export enum TraceType {
   STREAM = 'stream',
   VISUAL = 'visual',
   NO_REPLY = 'no-reply',
+  ENTITY_FILLING = 'entity-filling',
 }
 
 export interface BaseTraceFramePath<Event extends BaseEvent = BaseEvent> {

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -58,6 +58,14 @@ export interface NoReplyTrace extends BaseTraceFrame<NoReplyTracePayload> {
   type: TraceType.NO_REPLY;
 }
 
+export interface EntityFillingTracePayload {
+  entityToFill: string;
+  intent: IntentRequest;
+}
+export interface EntityFillingTrace extends BaseTraceFrame<EntityFillingTracePayload> {
+  type: TraceType.ENTITY_FILLING;
+}
+
 export type AnyTrace =
   | ExitTrace
   | TextTrace
@@ -69,4 +77,5 @@ export type AnyTrace =
   | ChoiceTrace
   | StreamTrace
   | VisualTrace
-  | NoReplyTrace;
+  | NoReplyTrace
+  | EntityFillingTrace;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2728**

### Brief description. What is this change?

Create a new trace type, when we are asking the user explicit to fill a certain entity during entity filling from intent/choice/button/capture steps.
(i.e. What is your email?)

We don't necessarily need to consume this trace, but any NLP/NLU outside of our default one that is used in conjunction with the runtime will need this.

The trace gives the intent we are trying to fill out, and the current entity we are prompting for.
