### PR TITLE
fix: mapping and utilities (VF-2613)

### DIFF
--- a/packages/alexa-types/src/constants/index.ts
+++ b/packages/alexa-types/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './apl';
 export * from './base';
 export * from './intents';
+export * from './mappings';
 export * from './slots';

--- a/packages/alexa-types/src/constants/intents.ts
+++ b/packages/alexa-types/src/constants/intents.ts
@@ -34,6 +34,12 @@ export enum AmazonIntent {
   VOICEFLOW = 'VoiceFlowIntent',
 }
 
+export enum IntentPrefix {
+  AMAZON = 'AMAZON',
+  CUSTOM = 'CUSTOM',
+  CAPTURE = 'CAPTURE',
+}
+
 export interface AlexaDefaultIntent extends Constants.DefaultIntent {
   keep?: string[];
 }

--- a/packages/alexa-types/src/constants/mappings.ts
+++ b/packages/alexa-types/src/constants/mappings.ts
@@ -1,0 +1,105 @@
+import { Constants as General } from '@voiceflow/general-types';
+
+import { Locale } from './base';
+import { AmazonIntent } from './intents';
+import { SlotType } from './slots';
+
+export const AMAZON_TOKEN_PREFIX = 't_';
+
+export enum IntentPrefix {
+  AMAZON = 'AMAZON',
+  CUSTOM = 'CUSTOM',
+  CAPTURE = 'CAPTURE',
+}
+
+export const AmazonToGeneralIntentMap: Partial<Record<AmazonIntent, General.IntentName>> = {
+  [AmazonIntent.NO]: General.IntentName.NO,
+  [AmazonIntent.YES]: General.IntentName.YES,
+  [AmazonIntent.STOP]: General.IntentName.STOP,
+  [AmazonIntent.NEXT]: General.IntentName.NEXT,
+  [AmazonIntent.HELP]: General.IntentName.HELP,
+  [AmazonIntent.PAUSE]: General.IntentName.PAUSE,
+  [AmazonIntent.CANCEL]: General.IntentName.CANCEL,
+  [AmazonIntent.RESUME]: General.IntentName.RESUME,
+  [AmazonIntent.REPEAT]: General.IntentName.REPEAT,
+  [AmazonIntent.FALLBACK]: General.IntentName.NONE,
+  [AmazonIntent.PREVIOUS]: General.IntentName.PREVIOUS,
+  [AmazonIntent.START_OVER]: General.IntentName.START_OVER,
+};
+
+export const GeneralToAmazonIntentMap: Partial<Record<General.IntentName, AmazonIntent>> = {
+  [General.IntentName.NO]: AmazonIntent.NO,
+  [General.IntentName.YES]: AmazonIntent.YES,
+  [General.IntentName.STOP]: AmazonIntent.STOP,
+  [General.IntentName.NEXT]: AmazonIntent.NEXT,
+  [General.IntentName.HELP]: AmazonIntent.HELP,
+  [General.IntentName.PAUSE]: AmazonIntent.PAUSE,
+  [General.IntentName.CANCEL]: AmazonIntent.CANCEL,
+  [General.IntentName.RESUME]: AmazonIntent.RESUME,
+  [General.IntentName.REPEAT]: AmazonIntent.REPEAT,
+  [General.IntentName.NONE]: AmazonIntent.FALLBACK,
+  [General.IntentName.PREVIOUS]: AmazonIntent.PREVIOUS,
+  [General.IntentName.START_OVER]: AmazonIntent.START_OVER,
+};
+
+export const AmazonToGeneralSlotMap: Partial<Record<SlotType, General.SlotType>> = {
+  [SlotType.TIME]: General.SlotType.DATETIME,
+  [SlotType.DATE]: General.SlotType.DATETIME,
+  [SlotType.FOUR_DIGIT_NUMBER]: General.SlotType.NUMBER,
+  [SlotType.NUMBER]: General.SlotType.NUMBER,
+  [SlotType.PHONENUMBER]: General.SlotType.PHONENUMBER,
+  [SlotType.PERSON]: General.SlotType.NAME,
+  [SlotType.DE_FIRST_NAME]: General.SlotType.NAME,
+  [SlotType.GB_FIRST_NAME]: General.SlotType.NAME,
+  [SlotType.US_FIRST_NAME]: General.SlotType.NAME,
+  [SlotType.FIRSTNAME]: General.SlotType.NAME,
+  [SlotType.ORDINAL]: General.SlotType.ORDINAL,
+};
+
+export const GeneralToAmazonSlotMap: Partial<Record<General.SlotType, SlotType>> = {
+  [General.SlotType.DATETIME]: SlotType.DATE,
+  [General.SlotType.NUMBER]: SlotType.NUMBER,
+  [General.SlotType.PHONENUMBER]: SlotType.PHONENUMBER,
+  [General.SlotType.NAME]: SlotType.FIRSTNAME,
+  [General.SlotType.ORDINAL]: SlotType.ORDINAL,
+};
+
+export const AmazonToGeneralLocaleMap: Record<Locale, General.Locale> = {
+  [Locale.EN_US]: General.Locale.EN_US,
+  [Locale.EN_AU]: General.Locale.EN_US,
+  [Locale.EN_CA]: General.Locale.EN_US,
+  [Locale.EN_IN]: General.Locale.EN_US,
+  [Locale.EN_GB]: General.Locale.EN_US,
+  [Locale.FR_CA]: General.Locale.FR_CA,
+  [Locale.ES_US]: General.Locale.ES_ES,
+  [Locale.FR_FR]: General.Locale.FR_FR,
+  [Locale.DE_DE]: General.Locale.DE_DE,
+  [Locale.IT_IT]: General.Locale.IT_IT,
+  [Locale.JA_JP]: General.Locale.JA_JP,
+  [Locale.ES_ES]: General.Locale.ES_ES,
+  [Locale.ES_MX]: General.Locale.ES_MX,
+  [Locale.PT_BR]: General.Locale.PT_BR,
+  [Locale.HI_IN]: General.Locale.HI_IN,
+};
+
+export const GeneralToAmazonLocaleMap: Record<General.Locale, Locale> = {
+  [General.Locale.EN_US]: Locale.EN_US,
+  [General.Locale.AR_AR]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.ZH_CN]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.NL_NL]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.FR_FR]: Locale.FR_FR,
+  [General.Locale.FR_CA]: Locale.FR_CA,
+  [General.Locale.DE_DE]: Locale.DE_DE,
+  [General.Locale.GU_IN]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.HI_IN]: Locale.HI_IN,
+  [General.Locale.IT_IT]: Locale.IT_IT,
+  [General.Locale.JA_JP]: Locale.JA_JP,
+  [General.Locale.KO_KR]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.MR_IN]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.PT_BR]: Locale.PT_BR,
+  [General.Locale.ES_ES]: Locale.ES_ES,
+  [General.Locale.ES_MX]: Locale.ES_MX,
+  [General.Locale.TA_IN]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.TE_IN]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+  [General.Locale.TR_TR]: Locale.EN_US, // FIXME: Unsupported language by Alexa
+};

--- a/packages/alexa-types/src/constants/mappings.ts
+++ b/packages/alexa-types/src/constants/mappings.ts
@@ -4,14 +4,6 @@ import { Locale } from './base';
 import { AmazonIntent } from './intents';
 import { SlotType } from './slots';
 
-export const AMAZON_TOKEN_PREFIX = 't_';
-
-export enum IntentPrefix {
-  AMAZON = 'AMAZON',
-  CUSTOM = 'CUSTOM',
-  CAPTURE = 'CAPTURE',
-}
-
 export const AmazonToGeneralIntentMap: Partial<Record<AmazonIntent, General.IntentName>> = {
   [AmazonIntent.NO]: General.IntentName.NO,
   [AmazonIntent.YES]: General.IntentName.YES,

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -10,6 +10,7 @@ export * as number from './number';
 export * as object from './object';
 export * as promise from './promise';
 export * as protocol from './protocol';
+export * as slot from './slot';
 export * as string from './string';
 export * as time from './time';
 export * as timezones from './timezones';

--- a/packages/common/src/utils/intent.ts
+++ b/packages/common/src/utils/intent.ts
@@ -2,6 +2,8 @@ import _sample from 'lodash/sample';
 
 import { BuiltinSlot, LOWER_CASE_CUSTOM_SLOT_TYPE, SLOT_REGEXP, SPACE_REGEXP } from '@/constants';
 
+import { getAllSamples } from './slot';
+
 export const formatIntentName = (name: string): string => {
   if (!name) {
     return name;
@@ -76,9 +78,6 @@ const continuousReplace = (text: string, regex: RegExp, replacer: (substring: st
   }
   return current;
 };
-
-// spread all synonyms into string array ['car, automobile', 'plane, jet'] => ['car', 'automobile', 'plane', 'jet']
-const getAllSamples = (inputs: string[] = []) => inputs.flatMap((input) => input.split(',')).filter((sample) => !!sample.trim());
 
 export const utteranceEntityPermutations = (
   utterances: string[],
@@ -183,3 +182,6 @@ export const injectUtteranceSpaces = (originalUtterance: string): string => {
 
   return utterance;
 };
+
+// VF.HELP -> help
+export const cleanVFIntentName = (intentName: string) => (intentName.startsWith('VF.') ? intentName.slice(3).toLowerCase() : intentName);

--- a/packages/common/src/utils/slot.ts
+++ b/packages/common/src/utils/slot.ts
@@ -1,0 +1,17 @@
+import _uniqBy from 'lodash/uniqBy';
+
+export const addPrebuiltEntities = <A extends { key: string; inputs: string[] }>(entities: A[], prebuiltEntities: Record<string, string[]>): A[] =>
+  entities.map((entity) => {
+    if (prebuiltEntities[entity.key]) {
+      return {
+        ...entity,
+        inputs: [...entity.inputs, ...prebuiltEntities[entity.key]],
+      };
+    }
+    return entity;
+  });
+
+export const getUniqueSamples = (input: string) => _uniqBy(input.split(','), (sample) => sample.toLowerCase());
+
+// spread all synonyms into string array ['car, automobile', 'plane, jet'] => ['car', 'automobile', 'plane', 'jet']
+export const getAllSamples = (inputs: string[] = []) => inputs.flatMap((input) => input.split(',')).filter((sample) => !!sample.trim());


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2613**

### Brief description. What is this change?

moved a bunch of utility functions out from services to a centralized location, and started adding in the mappings patterns with proper declarations and consistent names.

Check my comments for where they originally came from

We were using the `_invert` method to invert the array, but this has side effects because of many to one/one to many mappings. So it is better to be explicit