### PR TITLE
fix: union types generic (VF-000)

### DIFF
--- a/packages/common/src/utils/array.ts
+++ b/packages/common/src/utils/array.ts
@@ -126,5 +126,5 @@ export const filterAndGetLastRemovedValue = <T>(list: T[], filterFunc: (item: T)
   return [filteredList, lastItem];
 };
 
-type ArrayElem<A> = A extends Array<infer Elem> ? Elem : never;
-export const inferUnion = <T>(array: T): Array<ArrayElem<T>> => array as any as Array<ArrayElem<T>>;
+export type UnionArrays<A> = Array<A extends Array<infer Elem> ? Elem : never>;
+export const inferUnion = <T>(array: T): UnionArrays<T> => array as any as UnionArrays<T>;

--- a/packages/voiceflow-types/src/version/index.ts
+++ b/packages/voiceflow-types/src/version/index.ts
@@ -29,6 +29,8 @@ export type Version = VersionPerType[SupportedProjectType];
 export type Settings = SettingsPerType[SupportedProjectType];
 export type PlatformData = PlatformDataPerType[SupportedProjectType];
 
+export type Intent = PlatformData['intents'] extends (infer I)[] ? I : never;
+
 export const defaultPlatformData = <T extends SupportedProjectType>(
   type: T,
   platformData: DeepPartialByKey<PlatformDataPerType[T], 'settings'>


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
```
type A = B[] | C[];

type D = UnionArrays<A> // => (B | C)[]
```
