### PR TITLE
fix: fix types on inferUnion function (VF-000)

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -36,3 +36,14 @@ export type Struct = Record<string, unknown>;
  * @see https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492
  */
 export type EmptyObject = Record<never, never>;
+
+/** Avoids accidentally converting an immutable array type to a mutable one. */
+export type SafeArray<Element, Original> = Original extends Array<Element>
+  ? Element[]
+  : Original extends ReadonlyArray<Element>
+  ? ReadonlyArray<Element>
+  : Original extends ArrayLike<Element>
+  ? ArrayLike<Element>
+  : never;
+
+export type ArrayUnionToIntersection<T extends ArrayLike<unknown>> = SafeArray<T[number], T>;

--- a/packages/common/src/utils/array.ts
+++ b/packages/common/src/utils/array.ts
@@ -1,4 +1,4 @@
-import { Nullish } from '@common/types';
+import { ArrayUnionToIntersection, Nullish } from '@common/types';
 
 export const unique = <T>(items: T[]): T[] => Array.from(new Set(items));
 
@@ -126,5 +126,4 @@ export const filterAndGetLastRemovedValue = <T>(list: T[], filterFunc: (item: T)
   return [filteredList, lastItem];
 };
 
-export type UnionArrays<A> = Array<A extends Array<infer Elem> ? Elem : never>;
-export const inferUnion = <T>(array: T): UnionArrays<T> => array as any as UnionArrays<T>;
+export const inferUnion = <T extends ArrayLike<unknown>>(array: T): ArrayUnionToIntersection<T> => array as unknown as ArrayUnionToIntersection<T>;


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

fixes the type of the `inferUnion` function

### Implementation details. How do you make this change?

adds a `SafeArray` for stricter array type construction. also allows immutable arrays to be passed in.

replaces the `ArrayElem` type with a `ArrayUnionToIntersection` type to do effectively the same thing

arguably the `inferUnion` function should be renamed as in the TS ecosystem this operation is called "union to intersection" ([related](https://fettblog.eu/typescript-union-to-intersection/))

### Related PRs

closes #186

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written