### PR TITLE
refactor: use unique path aliases for each library in monorepo (vf-000)

### DIFF
--- a/packages/alexa-types/package.json
+++ b/packages/alexa-types/package.json
@@ -7,10 +7,10 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.10.0",
-    "@voiceflow/common": "^7.19.0",
-    "@voiceflow/voice-types": "^2.3.0",
-    "@voiceflow/voiceflow-types": "^3.4.0",
+    "@voiceflow/base-types": "2.10.0",
+    "@voiceflow/common": "7.19.0",
+    "@voiceflow/voice-types": "2.3.0",
+    "@voiceflow/voiceflow-types": "3.4.0",
     "ask-smapi-model": "1.14.0"
   },
   "files": [

--- a/packages/alexa-types/src/node/capture.ts
+++ b/packages/alexa-types/src/node/capture.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@alexa-types/constants';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 /** @deprecated */
 export interface StepData extends VoiceNode.Capture.StepData<Voice> {}

--- a/packages/alexa-types/src/node/captureV2.ts
+++ b/packages/alexa-types/src/node/captureV2.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@alexa-types/constants';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface StepData extends VoiceNode.CaptureV2.StepData<Voice> {}
 

--- a/packages/alexa-types/src/node/interaction.ts
+++ b/packages/alexa-types/src/node/interaction.ts
@@ -1,7 +1,6 @@
+import { Voice } from '@alexa-types/constants';
 import { BaseNode } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface StepData extends VoiceNode.Interaction.StepData<Voice> {}
 

--- a/packages/alexa-types/src/node/prompt.ts
+++ b/packages/alexa-types/src/node/prompt.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@alexa-types/constants';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface StepData extends VoiceNode.Prompt.StepData<Voice> {}
 

--- a/packages/alexa-types/src/node/speak.ts
+++ b/packages/alexa-types/src/node/speak.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@alexa-types/constants';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface StepData extends VoiceNode.Speak.StepData<Voice> {}
 

--- a/packages/alexa-types/src/project/product.ts
+++ b/packages/alexa-types/src/project/product.ts
@@ -1,4 +1,4 @@
-import { Locale, ProductType } from '@/constants';
+import { Locale, ProductType } from '@alexa-types/constants';
 
 export enum MarketPlace {
   DE = 'amazon.de',

--- a/packages/alexa-types/src/utils/node.ts
+++ b/packages/alexa-types/src/utils/node.ts
@@ -1,6 +1,5 @@
+import * as Node from '@alexa-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isSpeak = BaseUtils.node.createNodeTypeguard<Node.Speak.Node>(BaseNode.NodeType.SPEAK);
 export const isStream = BaseUtils.node.createNodeTypeguard<Node.Stream.Node>(BaseNode.NodeType.STREAM);

--- a/packages/alexa-types/src/utils/step.ts
+++ b/packages/alexa-types/src/utils/step.ts
@@ -1,6 +1,5 @@
+import * as Node from '@alexa-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isSpeak = BaseUtils.step.createStepTypeguard<Node.Speak.Step>(BaseNode.NodeType.SPEAK);
 export const isPrompt = BaseUtils.step.createStepTypeguard<Node.Prompt.Step>(BaseNode.NodeType.PROMPT);

--- a/packages/alexa-types/src/version/index.ts
+++ b/packages/alexa-types/src/version/index.ts
@@ -1,9 +1,8 @@
+import { Voice } from '@alexa-types/constants';
+import { AnyCommand } from '@alexa-types/node';
 import { BaseModels, DeepPartialByKey } from '@voiceflow/base-types';
 import { VoiceVersion } from '@voiceflow/voice-types';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
-
-import { Voice } from '@/constants';
-import { AnyCommand } from '@/node';
 
 import { defaultPublishing, Publishing } from './publishing';
 import { defaultSettings, Settings } from './settings';

--- a/packages/alexa-types/src/version/publishing.ts
+++ b/packages/alexa-types/src/version/publishing.ts
@@ -1,4 +1,4 @@
-import { Locale } from '@/constants';
+import { Locale } from '@alexa-types/constants';
 
 export interface Publishing {
   forExport: boolean;

--- a/packages/alexa-types/src/version/settings.ts
+++ b/packages/alexa-types/src/version/settings.ts
@@ -1,8 +1,7 @@
+import { Voice } from '@alexa-types/constants';
 import { Nullable } from '@voiceflow/base-types';
 import { VoiceVersion } from '@voiceflow/voice-types';
 import { v1 } from 'ask-smapi-model';
-
-import { Voice } from '@/constants';
 
 export enum AccountLinkingType {
   IMPLICIT = 'IMPLICIT',

--- a/packages/alexa-types/tsconfig.build.json
+++ b/packages/alexa-types/tsconfig.build.json
@@ -2,15 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@alexa-types/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": [
-    "node_modules/**",
-    "build/**",
-    "tests/**"
+  "include": [
+    "src/**/*",
+    "typings/**/*"
   ]
 }

--- a/packages/alexa-types/tsconfig.json
+++ b/packages/alexa-types/tsconfig.json
@@ -1,12 +1,43 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      "@voiceflow/common": [
+        "common/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@voiceflow/base-types": [
+        "base-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@base-types/*": [
+        "base-types/src/*"
+      ],
+      "@voiceflow/voice-types": [
+        "voice-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@voice-types/*": [
+        "voice-types/src/*"
+      ],
+      "@voiceflow/voiceflow-types": [
+        "voiceflow-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@voiceflow-types/*": [
+        "voiceflow-types/src/*"
+      ],
+      "@alexa-types/*": [
+        "alexa-types/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/api-sdk/.depcheckrc
+++ b/packages/api-sdk/.depcheckrc
@@ -2,6 +2,7 @@
   "specials": ["bin", "istanbul"],
   "ignores": [
     "@types/*",
+    "@api-sdk/*",
     "source-map-support"
   ]
 }

--- a/packages/api-sdk/example/index.ts
+++ b/packages/api-sdk/example/index.ts
@@ -1,4 +1,4 @@
-import ApiSDK from '@/index';
+import ApiSDK from '@api-sdk/.';
 
 const main = async () => {
   const apiSdk = new ApiSDK({ clientKey: 'mock', apiEndpoint: 'https://localhost:8080' });

--- a/packages/api-sdk/example/index.ts
+++ b/packages/api-sdk/example/index.ts
@@ -1,4 +1,4 @@
-import ApiSDK from '@api-sdk/.';
+import ApiSDK from '@api-sdk/index';
 
 const main = async () => {
   const apiSdk = new ApiSDK({ clientKey: 'mock', apiEndpoint: 'https://localhost:8080' });

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.10.0",
-    "@voiceflow/common": "^7.19.0",
+    "@voiceflow/base-types": "2.10.0",
+    "@voiceflow/common": "7.19.0",
     "axios": "0.24.0",
     "jwt-decode": "^3.1.2",
     "superstruct": "^0.10.12"

--- a/packages/api-sdk/src/client.ts
+++ b/packages/api-sdk/src/client.ts
@@ -1,5 +1,5 @@
-import { ClientOptions, PublicClient } from '@/publicclient';
-import { User } from '@/resources';
+import { ClientOptions, PublicClient } from '@api-sdk/publicclient';
+import { User } from '@api-sdk/resources';
 
 export class Client extends PublicClient {
   public user: User;

--- a/packages/api-sdk/src/index.ts
+++ b/packages/api-sdk/src/index.ts
@@ -1,11 +1,10 @@
+import { Client } from '@api-sdk/client';
+import { ClientOptions, PublicClient } from '@api-sdk/publicclient';
 import * as s from 'superstruct';
 
-import { Client } from '@/client';
-import { ClientOptions, PublicClient } from '@/publicclient';
-
-export type { Client } from '@/client';
-export type { PublicClient } from '@/publicclient';
-export type { Flatten } from '@/types';
+export type { Client } from '@api-sdk/client';
+export type { PublicClient } from '@api-sdk/publicclient';
+export type { Flatten } from '@api-sdk/types';
 
 export const SParams = s.object({
   clientKey: s.string(),

--- a/packages/api-sdk/src/publicclient.ts
+++ b/packages/api-sdk/src/publicclient.ts
@@ -1,7 +1,6 @@
+import Fetch, { FetchConfig } from '@api-sdk/fetch';
+import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, Version } from '@api-sdk/resources';
 import { Crypto } from '@voiceflow/common';
-
-import Fetch, { FetchConfig } from '@/fetch';
-import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, Version } from '@/resources';
 
 export interface ClientOptions {
   options?: FetchConfig;

--- a/packages/api-sdk/src/resources/analytics.ts
+++ b/packages/api-sdk/src/resources/analytics.ts
@@ -1,6 +1,5 @@
+import type Fetch from '@api-sdk/fetch';
 import { Crypto } from '@voiceflow/common';
-
-import type Fetch from '@/fetch';
 
 import Fetcher from './fetcher';
 

--- a/packages/api-sdk/src/resources/apiKey.ts
+++ b/packages/api-sdk/src/resources/apiKey.ts
@@ -1,6 +1,5 @@
+import type Fetch from '@api-sdk/fetch';
 import { BaseModels } from '@voiceflow/base-types';
-
-import type Fetch from '@/fetch';
 
 import CrudResource from './crud';
 

--- a/packages/api-sdk/src/resources/crud.ts
+++ b/packages/api-sdk/src/resources/crud.ts
@@ -1,6 +1,5 @@
+import type { PutPostType, SchemeType } from '@api-sdk/types';
 import type { AnyRecord } from '@voiceflow/base-types';
-
-import type { PutPostType, SchemeType } from '@/types';
 
 import BaseResource, { Fields } from './base';
 

--- a/packages/api-sdk/src/resources/diagram.ts
+++ b/packages/api-sdk/src/resources/diagram.ts
@@ -1,6 +1,5 @@
+import type Fetch from '@api-sdk/fetch';
 import { BaseModels } from '@voiceflow/base-types';
-
-import type Fetch from '@/fetch';
 
 import { Fields } from './base';
 import CrudResource from './crud';

--- a/packages/api-sdk/src/resources/fetcher.ts
+++ b/packages/api-sdk/src/resources/fetcher.ts
@@ -1,4 +1,4 @@
-import type Fetch from '@/fetch';
+import type Fetch from '@api-sdk/fetch';
 
 type Clazz<Client, Options = undefined> = Options extends undefined ? new (fetch: Fetch) => Client : new (fetch: Fetch, options: Options) => Client;
 

--- a/packages/api-sdk/src/resources/program.ts
+++ b/packages/api-sdk/src/resources/program.ts
@@ -1,6 +1,5 @@
+import type Fetch from '@api-sdk/fetch';
 import { BaseModels } from '@voiceflow/base-types';
-
-import type Fetch from '@/fetch';
 
 import { Fields } from './base';
 import CrudResource from './crud';

--- a/packages/api-sdk/src/resources/project/index.ts
+++ b/packages/api-sdk/src/resources/project/index.ts
@@ -1,6 +1,5 @@
+import type Fetch from '@api-sdk/fetch';
 import { AnyRecord, BaseModels } from '@voiceflow/base-types';
-
-import type Fetch from '@/fetch';
 
 import { Fields } from '../base';
 import CrudResource from '../crud';

--- a/packages/api-sdk/src/resources/project/member.ts
+++ b/packages/api-sdk/src/resources/project/member.ts
@@ -1,6 +1,5 @@
+import Fetch, { PathVariables } from '@api-sdk/fetch';
 import { AnyRecord, BaseModels } from '@voiceflow/base-types';
-
-import Fetch, { PathVariables } from '@/fetch';
 
 import BaseResource, { Fields } from '../base';
 import { ENDPOINT } from './constants';

--- a/packages/api-sdk/src/resources/prototypeProgram.ts
+++ b/packages/api-sdk/src/resources/prototypeProgram.ts
@@ -1,4 +1,4 @@
-import type Fetch from '@/fetch';
+import type Fetch from '@api-sdk/fetch';
 
 import ProgramResource from './program';
 

--- a/packages/api-sdk/src/resources/version.ts
+++ b/packages/api-sdk/src/resources/version.ts
@@ -1,6 +1,5 @@
+import Fetch from '@api-sdk/fetch';
 import { AnyRecord, BaseModels } from '@voiceflow/base-types';
-
-import Fetch from '@/fetch';
 
 import { Fields } from './base';
 import CrudResource from './crud';

--- a/packages/api-sdk/tests/client.unit.ts
+++ b/packages/api-sdk/tests/client.unit.ts
@@ -1,9 +1,8 @@
+import { Client } from '@api-sdk/client';
+import Fetch from '@api-sdk/fetch';
+import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, User, Version } from '@api-sdk/resources';
 import { expect } from 'chai';
 import JWT from 'jsonwebtoken';
-
-import { Client } from '@/client';
-import Fetch from '@/fetch';
-import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, User, Version } from '@/resources';
 
 const CLIENT_RESOURCES = [Fetch, Diagram, Program, Project, Version, User, APIKey, Analytics];
 

--- a/packages/api-sdk/tests/fetch.unit.ts
+++ b/packages/api-sdk/tests/fetch.unit.ts
@@ -1,10 +1,9 @@
 /* eslint-disable dot-notation */
 
+import Fetch, { FetchConfig } from '@api-sdk/fetch';
 import baseAxios from 'axios';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import Fetch, { FetchConfig } from '@/fetch';
 
 const CLIENT_KEY = '123qwe123';
 const AUTHORIZATION = 'qwe123qwe';

--- a/packages/api-sdk/tests/index.unit.ts
+++ b/packages/api-sdk/tests/index.unit.ts
@@ -1,12 +1,11 @@
 /* eslint-disable dot-notation */
+import { Client } from '@api-sdk/client';
+import ApiSDK, { SGenerateClientParams, SParams } from '@api-sdk/index';
+import { PublicClient } from '@api-sdk/publicclient';
 import { expect } from 'chai';
 import JWT from 'jsonwebtoken';
 import sinon from 'sinon';
 import * as s from 'superstruct';
-
-import { Client } from '@/client';
-import ApiSDK, { SGenerateClientParams, SParams } from '@/index';
-import { PublicClient } from '@/publicclient';
 
 const createSDK = () => {
   const assert = sinon.stub(s, 'assert');

--- a/packages/api-sdk/tests/resources/_crud.unit.ts
+++ b/packages/api-sdk/tests/resources/_crud.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
 
+import CrudResource from '@api-sdk/resources/crud';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import CrudResource from '@/resources/crud';
 
 const RESPONSE_DATA = {
   data: { field1: '1', field2: { subfield: [1, 10] } },

--- a/packages/api-sdk/tests/resources/analytics.unit.ts
+++ b/packages/api-sdk/tests/resources/analytics.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
 
+import Analytics from '@api-sdk/resources/analytics';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import Analytics from '@/resources/analytics';
 
 const createClient = (encrypted = false) => {
   const fetch = {

--- a/packages/api-sdk/tests/resources/apiKey.unit.ts
+++ b/packages/api-sdk/tests/resources/apiKey.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
+import { APIKey } from '@api-sdk/resources';
+import Crud from '@api-sdk/resources/crud';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { APIKey } from '@/resources';
-import Crud from '@/resources/crud';
 
 const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
 

--- a/packages/api-sdk/tests/resources/base.unit.ts
+++ b/packages/api-sdk/tests/resources/base.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
 
+import BaseResource from '@api-sdk/resources/base';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import BaseResource from '@/resources/base';
 
 const createClient = () => {
   const fetch = {

--- a/packages/api-sdk/tests/resources/diagram.unit.ts
+++ b/packages/api-sdk/tests/resources/diagram.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
+import { Diagram } from '@api-sdk/resources';
+import Crud from '@api-sdk/resources/crud';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { Diagram } from '@/resources';
-import Crud from '@/resources/crud';
 
 const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
 

--- a/packages/api-sdk/tests/resources/program.unit.ts
+++ b/packages/api-sdk/tests/resources/program.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
+import { Program } from '@api-sdk/resources';
+import Crud from '@api-sdk/resources/crud';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { Program } from '@/resources';
-import Crud from '@/resources/crud';
 
 const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
 

--- a/packages/api-sdk/tests/resources/project/index.unit.ts
+++ b/packages/api-sdk/tests/resources/project/index.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
+import { Project } from '@api-sdk/resources';
+import Crud from '@api-sdk/resources/crud';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { Project } from '@/resources';
-import Crud from '@/resources/crud';
 
 const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
 

--- a/packages/api-sdk/tests/resources/project/member.unit.ts
+++ b/packages/api-sdk/tests/resources/project/member.unit.ts
@@ -1,8 +1,7 @@
 /* eslint-disable dot-notation */
+import Member from '@api-sdk/resources/project/member';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import Member from '@/resources/project/member';
 
 const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
 

--- a/packages/api-sdk/tests/resources/prototypeProgram.unit.ts
+++ b/packages/api-sdk/tests/resources/prototypeProgram.unit.ts
@@ -1,7 +1,6 @@
 /* eslint-disable dot-notation */
+import { Program, PrototypeProgram } from '@api-sdk/resources';
 import { expect } from 'chai';
-
-import { Program, PrototypeProgram } from '@/resources';
 
 describe('PrototypeProgramResource', () => {
   it('instance of ProgramResource', async () => {

--- a/packages/api-sdk/tests/resources/user.unit.ts
+++ b/packages/api-sdk/tests/resources/user.unit.ts
@@ -1,8 +1,7 @@
 /* eslint-disable dot-notation */
+import { User } from '@api-sdk/resources';
 import { expect } from 'chai';
 import JWT from 'jsonwebtoken';
-
-import { User } from '@/resources';
 
 const USER_HASH = 'UserHash_16chars';
 const SAMPLE_USER = {

--- a/packages/api-sdk/tests/resources/version.unit.ts
+++ b/packages/api-sdk/tests/resources/version.unit.ts
@@ -1,9 +1,8 @@
 /* eslint-disable dot-notation */
+import { Version } from '@api-sdk/resources';
+import Crud from '@api-sdk/resources/crud';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { Version } from '@/resources';
-import Crud from '@/resources/crud';
 
 const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
 

--- a/packages/api-sdk/tsconfig.build.json
+++ b/packages/api-sdk/tsconfig.build.json
@@ -2,16 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@api-sdk/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": [
-    "node_modules/**",
-    "build/**",
-    "example/**",
-    "tests/**"
+  "include": [
+    "src/**/*",
+    "typings/**/*"
   ]
 }

--- a/packages/api-sdk/tsconfig.json
+++ b/packages/api-sdk/tsconfig.json
@@ -1,13 +1,26 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "lib": ["es2017", "DOM"],
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@voiceflow/base-types": [
+        "base-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@base-types/*": [
+        "base-types/src/*"
+      ],
+      "@api-sdk/*": [
+        "api-sdk/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/base-types/package.json
+++ b/packages/base-types/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/common": "^7.19.0",
+    "@voiceflow/common": "7.19.0",
     "slate": "0.63.0"
   },
   "files": [

--- a/packages/base-types/src/button/index.ts
+++ b/packages/base-types/src/button/index.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 export enum ButtonType {
   INTENT = 'INTENT',

--- a/packages/base-types/src/models/apiKey.ts
+++ b/packages/base-types/src/models/apiKey.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@/types';
+import { AnyRecord } from '@base-types/types';
 
 export interface Model<Data extends AnyRecord = AnyRecord> {
   _id: string;

--- a/packages/base-types/src/models/base/command.ts
+++ b/packages/base-types/src/models/base/command.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@/types';
+import { AnyRecord } from '@base-types/types';
 
 import { Variable } from './common';
 

--- a/packages/base-types/src/models/base/node.ts
+++ b/packages/base-types/src/models/base/node.ts
@@ -1,4 +1,4 @@
-import { AnyRecord, Nullable } from '@/types';
+import { AnyRecord, Nullable } from '@base-types/types';
 
 /**
  * @deprecated use BaseNode instead

--- a/packages/base-types/src/models/base/slot.ts
+++ b/packages/base-types/src/models/base/slot.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { Variable } from './common';
 

--- a/packages/base-types/src/models/project/index.ts
+++ b/packages/base-types/src/models/project/index.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@/types';
+import { AnyRecord } from '@base-types/types';
 
 import { Member } from './member';
 import { Prototype } from './prototype';

--- a/packages/base-types/src/models/project/member.ts
+++ b/packages/base-types/src/models/project/member.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@/types';
+import { AnyRecord } from '@base-types/types';
 
 export interface Member<P extends AnyRecord = AnyRecord> {
   creatorID: number;

--- a/packages/base-types/src/models/project/prototype.ts
+++ b/packages/base-types/src/models/project/prototype.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@/types';
+import { AnyRecord } from '@base-types/types';
 
 import { ProjectNLP, PrototypeModel } from '../base';
 

--- a/packages/base-types/src/models/version/index.ts
+++ b/packages/base-types/src/models/version/index.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@/types';
+import { AnyRecord } from '@base-types/types';
 
 import { BaseCommand, Intent, Slot, Variable } from '../base';
 import { Prototype } from './prototype';

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -1,4 +1,4 @@
-import { AnyRecord, Nullable } from '@/types';
+import { AnyRecord, Nullable } from '@base-types/types';
 
 import { BaseCommand, PrototypeModel } from '../base';
 

--- a/packages/base-types/src/node/_v1.ts
+++ b/packages/base-types/src/node/_v1.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { BaseEvent, BaseNode, BasePort, BaseStep, NodeID } from './utils';
 

--- a/packages/base-types/src/node/api.ts
+++ b/packages/base-types/src/node/api.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseStep, IntegrationType, NodeSuccessFailID } from './utils';

--- a/packages/base-types/src/node/buttons.ts
+++ b/packages/base-types/src/node/buttons.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { StepButtonsLayout } from '../button';
 import { NodeType } from './constants';

--- a/packages/base-types/src/node/capture.ts
+++ b/packages/base-types/src/node/capture.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseNodeNoReply, BaseStep, BaseStepNoReply, NodeNextID } from './utils';

--- a/packages/base-types/src/node/captureV2.ts
+++ b/packages/base-types/src/node/captureV2.ts
@@ -1,5 +1,5 @@
-import { Intent } from '@/models';
-import { Nullable } from '@/types';
+import { Intent } from '@base-types/models';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseNodeNoMatch, BaseNodeNoReply, BaseStep, BaseStepNoMatch, BaseStepNoReply, NodeNextID } from './utils';

--- a/packages/base-types/src/node/exit.ts
+++ b/packages/base-types/src/node/exit.ts
@@ -1,4 +1,4 @@
-import { UnknownRecord } from '@/types';
+import { UnknownRecord } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, TraceType } from './utils';

--- a/packages/base-types/src/node/flow.ts
+++ b/packages/base-types/src/node/flow.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID, NodeVariablesMappings, TraceType } from './utils';

--- a/packages/base-types/src/node/general.ts
+++ b/packages/base-types/src/node/general.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID } from './utils';

--- a/packages/base-types/src/node/googleSheets.ts
+++ b/packages/base-types/src/node/googleSheets.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID } from './utils';

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -1,5 +1,5 @@
-import { AnyRequestButton } from '@/request';
-import { Nullable } from '@/types';
+import { AnyRequestButton } from '@base-types/request';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import {

--- a/packages/base-types/src/node/jump.ts
+++ b/packages/base-types/src/node/jump.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseCommand, BaseStep, NodeID, SlotMappings } from './utils';

--- a/packages/base-types/src/node/prompt.ts
+++ b/packages/base-types/src/node/prompt.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseStep, BaseStepNoMatch, BaseStepNoReply } from './utils';

--- a/packages/base-types/src/node/push.ts
+++ b/packages/base-types/src/node/push.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseCommand, BasePort, BaseStep, NodeID, SlotMappings } from './utils';

--- a/packages/base-types/src/node/set.ts
+++ b/packages/base-types/src/node/set.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, Expression, NodeNextID } from './utils';

--- a/packages/base-types/src/node/setV2.ts
+++ b/packages/base-types/src/node/setV2.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, ExpressionTypeV2, NodeNextID } from './utils';

--- a/packages/base-types/src/node/speak.ts
+++ b/packages/base-types/src/node/speak.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID, StepCanvasNodeVisibility, TraceType } from './utils';

--- a/packages/base-types/src/node/text.ts
+++ b/packages/base-types/src/node/text.ts
@@ -1,4 +1,4 @@
-import { SlateTextValue } from '@/text';
+import { SlateTextValue } from '@base-types/text';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, DataID, NodeNextID, StepCanvasNodeVisibility, TraceType } from './utils';

--- a/packages/base-types/src/node/utils/base.ts
+++ b/packages/base-types/src/node/utils/base.ts
@@ -1,6 +1,6 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
-export { BaseCommand, BaseNode, BasePort, BaseStep } from '@/models';
+export { BaseCommand, BaseNode, BasePort, BaseStep } from '@base-types/models';
 
 export type NodeID = Nullable<string>;
 

--- a/packages/base-types/src/node/utils/command.ts
+++ b/packages/base-types/src/node/utils/command.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { BaseCommand } from './base';
 import { BaseEvent } from './event';

--- a/packages/base-types/src/node/utils/event.ts
+++ b/packages/base-types/src/node/utils/event.ts
@@ -1,4 +1,4 @@
-import { IntentRequest } from '@/request';
+import { IntentRequest } from '@base-types/request';
 
 import { SlotMappings } from './mappings';
 

--- a/packages/base-types/src/node/utils/expression.ts
+++ b/packages/base-types/src/node/utils/expression.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 export enum ExpressionType {
   EQUALS = 'equals',

--- a/packages/base-types/src/node/utils/integration.ts
+++ b/packages/base-types/src/node/utils/integration.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 export enum IntegrationType {
   ZAPIER = 'Zapier',

--- a/packages/base-types/src/node/utils/mappings.ts
+++ b/packages/base-types/src/node/utils/mappings.ts
@@ -1,4 +1,4 @@
-import { SlotMapping } from '@/models';
+import { SlotMapping } from '@base-types/models';
 
 export interface SlotMappings {
   mappings?: SlotMapping[];

--- a/packages/base-types/src/node/utils/noMatch.ts
+++ b/packages/base-types/src/node/utils/noMatch.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeID } from './base';
 

--- a/packages/base-types/src/node/utils/noReply.ts
+++ b/packages/base-types/src/node/utils/noReply.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeID } from './base';
 

--- a/packages/base-types/src/node/visual.ts
+++ b/packages/base-types/src/node/visual.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID, TraceType } from './utils';

--- a/packages/base-types/src/project/index.ts
+++ b/packages/base-types/src/project/index.ts
@@ -1,5 +1,5 @@
-import { Project as ProjectModels } from '@/models';
-import { AnyRecord } from '@/types';
+import { Project as ProjectModels } from '@base-types/models';
+import { AnyRecord } from '@base-types/types';
 
 export interface PlatformData extends AnyRecord {}
 

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -1,21 +1,21 @@
-import { TraceFrame as ExitTrace } from '@/node/exit';
-import { TraceFrame as FlowTrace } from '@/node/flow';
-import { TraceFrame as ChoiceTrace } from '@/node/interaction';
-import { TraceFrame as SpeakTrace } from '@/node/speak';
-import { TraceFrame as StreamTrace } from '@/node/stream';
-import { TraceFrame as TextTrace } from '@/node/text';
-import { BaseTraceFrame, TraceType } from '@/node/utils';
-import { TraceFrame as VisualTrace } from '@/node/visual';
-import { IntentRequest } from '@/request';
+import { TraceFrame as ExitTrace } from '@base-types/node/exit';
+import { TraceFrame as FlowTrace } from '@base-types/node/flow';
+import { TraceFrame as ChoiceTrace } from '@base-types/node/interaction';
+import { TraceFrame as SpeakTrace } from '@base-types/node/speak';
+import { TraceFrame as StreamTrace } from '@base-types/node/stream';
+import { TraceFrame as TextTrace } from '@base-types/node/text';
+import { BaseTraceFrame, TraceType } from '@base-types/node/utils';
+import { TraceFrame as VisualTrace } from '@base-types/node/visual';
+import { IntentRequest } from '@base-types/request';
 
-export { TraceFrame as ExitTrace } from '@/node/exit';
-export { TraceFrame as FlowTrace } from '@/node/flow';
-export { TraceFrame as ChoiceTrace } from '@/node/interaction';
-export { TraceFrame as SpeakTrace } from '@/node/speak';
-export { TraceFrame as StreamTrace } from '@/node/stream';
-export { TraceFrame as TextTrace } from '@/node/text';
-export { TraceType } from '@/node/utils/trace';
-export { TraceFrame as VisualTrace } from '@/node/visual';
+export { TraceFrame as ExitTrace } from '@base-types/node/exit';
+export { TraceFrame as FlowTrace } from '@base-types/node/flow';
+export { TraceFrame as ChoiceTrace } from '@base-types/node/interaction';
+export { TraceFrame as SpeakTrace } from '@base-types/node/speak';
+export { TraceFrame as StreamTrace } from '@base-types/node/stream';
+export { TraceFrame as TextTrace } from '@base-types/node/text';
+export { TraceType } from '@base-types/node/utils/trace';
+export { TraceFrame as VisualTrace } from '@base-types/node/visual';
 
 export interface DebugTracePayload {
   type?: string;

--- a/packages/base-types/src/utils/node.ts
+++ b/packages/base-types/src/utils/node.ts
@@ -1,7 +1,6 @@
+import * as BaseModels from '@base-types/models';
+import * as Node from '@base-types/node';
 import { Utils } from '@voiceflow/common';
-
-import * as BaseModels from '@/models';
-import * as Node from '@/node';
 
 export const createNodeTypeguard = Utils.typeguard.createTypedTypeguardCreator<BaseModels.BaseNode>();
 

--- a/packages/base-types/src/utils/step.ts
+++ b/packages/base-types/src/utils/step.ts
@@ -1,7 +1,6 @@
+import * as BaseModels from '@base-types/models';
+import * as Node from '@base-types/node';
 import { Utils } from '@voiceflow/common';
-
-import * as BaseModels from '@/models';
-import * as Node from '@/node';
 
 export const createStepTypeguard = Utils.typeguard.createTypedTypeguardCreator<BaseModels.BaseDiagramNode>();
 

--- a/packages/base-types/src/version/index.ts
+++ b/packages/base-types/src/version/index.ts
@@ -1,5 +1,5 @@
-import { Version as VersionModels } from '@/models';
-import { DeepPartialByKey } from '@/types';
+import { Version as VersionModels } from '@base-types/models';
+import { DeepPartialByKey } from '@base-types/types';
 
 import { defaultSettings, Settings } from './settings';
 

--- a/packages/base-types/src/version/settings.ts
+++ b/packages/base-types/src/version/settings.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@/types';
+import { Nullable } from '@base-types/types';
 
 import { Utils } from '../node';
 

--- a/packages/base-types/tsconfig.build.json
+++ b/packages/base-types/tsconfig.build.json
@@ -2,11 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@base-types/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": ["node_modules/**", "build/**", "tests/**"]
+  "include": [
+    "src/**/*",
+    "typings/**/*"
+  ]
 }

--- a/packages/base-types/tsconfig.json
+++ b/packages/base-types/tsconfig.json
@@ -1,12 +1,22 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      "@voiceflow/common": [
+        "common/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@base-types/*": [
+        "base-types/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.10.0"
+    "@voiceflow/base-types": "2.10.0"
   },
   "files": [
     "build"

--- a/packages/chat-types/src/node/captureV2.ts
+++ b/packages/chat-types/src/node/captureV2.ts
@@ -1,6 +1,5 @@
+import { Intent } from '@chat-types/models';
 import { BaseNode, Nullable } from '@voiceflow/base-types';
-
-import { Intent } from '@/models';
 
 import { NodeNoMatch, NodeNoReply, StepNoMatch, StepNoReply } from './utils';
 

--- a/packages/chat-types/src/node/utils.ts
+++ b/packages/chat-types/src/node/utils.ts
@@ -1,6 +1,5 @@
+import { Prompt } from '@chat-types/models';
 import { BaseNode, BaseText, Nullable } from '@voiceflow/base-types';
-
-import { Prompt } from '@/models';
 
 export interface StepNoReply extends BaseNode.Utils.StepNoReply<Prompt> {}
 

--- a/packages/chat-types/src/utils/node.ts
+++ b/packages/chat-types/src/utils/node.ts
@@ -1,6 +1,5 @@
+import * as Node from '@chat-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isCapture = BaseUtils.node.createNodeTypeguard<Node.Capture.Node>(BaseNode.NodeType.CAPTURE);
 export const isCaptureV2 = BaseUtils.node.createNodeTypeguard<Node.CaptureV2.Node>(BaseNode.NodeType.CAPTURE_V2);

--- a/packages/chat-types/src/utils/prompt.ts
+++ b/packages/chat-types/src/utils/prompt.ts
@@ -1,6 +1,5 @@
+import { Prompt } from '@chat-types/models';
 import { Nullable } from '@voiceflow/base-types';
-
-import { Prompt } from '@/models';
 
 export const defaultPrompt = (prompt: Nullable<Prompt> | undefined): Nullable<Prompt> => {
   if (!prompt?.content) {

--- a/packages/chat-types/src/utils/step.ts
+++ b/packages/chat-types/src/utils/step.ts
@@ -1,6 +1,5 @@
+import * as Node from '@chat-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isPrompt = BaseUtils.step.createStepTypeguard<Node.Prompt.Step>(BaseNode.NodeType.PROMPT);
 export const isButtons = BaseUtils.step.createStepTypeguard<Node.Buttons.Step>(BaseNode.NodeType.BUTTONS);

--- a/packages/chat-types/src/version/index.ts
+++ b/packages/chat-types/src/version/index.ts
@@ -1,6 +1,5 @@
+import { Intent, Prompt } from '@chat-types/models';
 import { BaseModels, BaseVersion, DeepPartialByKey } from '@voiceflow/base-types';
-
-import { Intent, Prompt } from '@/models';
 
 import { defaultSettings, Settings } from './settings';
 

--- a/packages/chat-types/src/version/settings.ts
+++ b/packages/chat-types/src/version/settings.ts
@@ -1,7 +1,6 @@
+import { Prompt } from '@chat-types/models';
+import { prompt } from '@chat-types/utils';
 import { BaseModels, BaseVersion } from '@voiceflow/base-types';
-
-import { Prompt } from '@/models';
-import { prompt } from '@/utils';
 
 export interface Settings extends BaseVersion.Settings<Prompt> {
   session: BaseVersion.Session<Prompt>;

--- a/packages/chat-types/tsconfig.build.json
+++ b/packages/chat-types/tsconfig.build.json
@@ -2,15 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@chat-types/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": [
-    "node_modules/**",
-    "build/**",
-    "tests/**"
+  "include": [
+    "src/**/*",
+    "typings/**/*"
   ]
 }

--- a/packages/chat-types/tsconfig.json
+++ b/packages/chat-types/tsconfig.json
@@ -1,12 +1,26 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@voiceflow/base-types": [
+        "base-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@base-types/*": [
+        "base-types/src/*"
+      ],
+      "@chat-types/*": [
+        "chat-types/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/common/src/crypto/murmurhash.ts
+++ b/packages/common/src/crypto/murmurhash.ts
@@ -1,6 +1,5 @@
+import { hex2abc } from '@common/crypto/hex2abc';
 import { MurmurHash3 } from 'murmurhash-wasm';
-
-import { hex2abc } from '@/crypto/hex2abc';
 
 export class MurmurHash {
   public static hash(key: string, seed = 0): string {

--- a/packages/common/src/utils/array.ts
+++ b/packages/common/src/utils/array.ts
@@ -1,4 +1,4 @@
-import { Nullish } from '@/types';
+import { Nullish } from '@common/types';
 
 export const unique = <T>(items: T[]): T[] => Array.from(new Set(items));
 

--- a/packages/common/src/utils/intent.ts
+++ b/packages/common/src/utils/intent.ts
@@ -1,6 +1,5 @@
+import { BuiltinSlot, LOWER_CASE_CUSTOM_SLOT_TYPE, SLOT_REGEXP, SPACE_REGEXP } from '@common/constants';
 import _sample from 'lodash/sample';
-
-import { BuiltinSlot, LOWER_CASE_CUSTOM_SLOT_TYPE, SLOT_REGEXP, SPACE_REGEXP } from '@/constants';
 
 import { getAllSamples } from './slot';
 

--- a/packages/common/src/utils/normalized.ts
+++ b/packages/common/src/utils/normalized.ts
@@ -1,4 +1,4 @@
-import { Normalized } from '@/types';
+import { Normalized } from '@common/types';
 
 import { withoutValue } from './array';
 import { stringify } from './functional';

--- a/packages/common/src/utils/variables.ts
+++ b/packages/common/src/utils/variables.ts
@@ -1,4 +1,4 @@
-import { READABLE_VARIABLE_REGEXP } from '@/constants';
+import { READABLE_VARIABLE_REGEXP } from '@common/constants';
 
 export const variableReplacer = (
   match: string,

--- a/packages/common/tests/crypto/hex2abc.ts
+++ b/packages/common/tests/crypto/hex2abc.ts
@@ -1,6 +1,5 @@
+import { hex2abc } from '@common/crypto/hex2abc';
 import { expect } from 'chai';
-
-import { hex2abc } from '@/crypto/hex2abc';
 
 describe('hex2abc()', () => {
   it('works', () => {

--- a/packages/common/tests/crypto/murmurhash.unit.ts
+++ b/packages/common/tests/crypto/murmurhash.unit.ts
@@ -1,6 +1,5 @@
+import { MurmurHash } from '@common/crypto/murmurhash';
 import { expect } from 'chai';
-
-import { MurmurHash } from '@/crypto/murmurhash';
 
 // for second test check (4 byte chunk)
 // const buf_left = Buffer.of(0xff, 0xff, 0xff, 0xff);

--- a/packages/common/tests/utils/array.unit.ts
+++ b/packages/common/tests/utils/array.unit.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 import {
   append,
   filterOutNullish,
@@ -15,7 +13,8 @@ import {
   without,
   withoutValue,
   withoutValues,
-} from '@/utils/array';
+} from '@common/utils/array';
+import { expect } from 'chai';
 
 describe('Utils | array', () => {
   describe('unique()', () => {

--- a/packages/common/tests/utils/intent.unit.ts
+++ b/packages/common/tests/utils/intent.unit.ts
@@ -1,6 +1,5 @@
+import { injectUtteranceSpaces, utteranceEntityPermutations } from '@common/utils/intent';
 import { expect } from 'chai';
-
-import { injectUtteranceSpaces, utteranceEntityPermutations } from '@/utils/intent';
 
 import * as data from '../fixtures/name.json';
 

--- a/packages/common/tests/utils/protocol.unit.ts
+++ b/packages/common/tests/utils/protocol.unit.ts
@@ -1,6 +1,5 @@
+import { Channel, createChannel, typeFactory } from '@common/utils/protocol';
 import { expect } from 'chai';
-
-import { Channel, createChannel, typeFactory } from '@/utils/protocol';
 
 describe('Utils | protocol', () => {
   describe('typeFactory()', () => {

--- a/packages/common/tsconfig.build.json
+++ b/packages/common/tsconfig.build.json
@@ -1,11 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "build/common",
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": ["node_modules/**", "example/**", "tests/**"]
+  "include": [
+    "src/**/*",
+    "typings/**/*"
+  ]
 }

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,38 +1,18 @@
 {
+  "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "target": "es2017",
-    "moduleResolution": "node",
-    "module": "commonjs",
-    "declaration": true,
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "experimentalDecorators": true,
-    /* Strictness Checks */
-    "alwaysStrict": true,
-    "noImplicitAny": true,
-    "noUnusedLocals": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "noFallthroughCasesInSwitch": true,
-    "strictPropertyInitialization": true,
-    /* Debugging Options */
-    "traceResolution": false,
-    "listEmittedFiles": false,
-    "listFiles": false,
-    "pretty": true,
-    "lib": ["es2020"],
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "lib": [
+      "es2020"
+    ],
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@common/*": [
+        "src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "include": ["src/**/*.ts", "typings/**/*.d.ts", "tests/**/*.ts"],
-  "exclude": ["node_modules/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/google-dfes-types/package.json
+++ b/packages/google-dfes-types/package.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.10.0",
-    "@voiceflow/chat-types": "^2.4.0",
-    "@voiceflow/common": "^7.19.0",
-    "@voiceflow/google-types": "^2.5.0",
-    "@voiceflow/voice-types": "^2.3.0",
-    "@voiceflow/voiceflow-types": "^3.4.0"
+    "@voiceflow/base-types": "2.10.0",
+    "@voiceflow/chat-types": "2.4.0",
+    "@voiceflow/common": "7.19.0",
+    "@voiceflow/google-types": "2.5.0",
+    "@voiceflow/voice-types": "2.3.0",
+    "@voiceflow/voiceflow-types": "3.4.0"
   },
   "files": [
     "build"

--- a/packages/google-dfes-types/src/utils/node.ts
+++ b/packages/google-dfes-types/src/utils/node.ts
@@ -1,6 +1,5 @@
+import * as Node from '@google-dfes-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isVisual = BaseUtils.node.createNodeTypeguard<Node.Visual.Node>(BaseNode.NodeType.VISUAL);
 export const isPayload = BaseUtils.node.createNodeTypeguard<Node.Payload.Node>(Node.NodeType.PAYLOAD);

--- a/packages/google-dfes-types/src/utils/step.ts
+++ b/packages/google-dfes-types/src/utils/step.ts
@@ -1,6 +1,5 @@
+import * as Node from '@google-dfes-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isVisual = BaseUtils.step.createStepTypeguard<Node.Visual.Step>(BaseNode.NodeType.VISUAL);
 export const isPayload = BaseUtils.step.createStepTypeguard<Node.Payload.Step>(Node.NodeType.PAYLOAD);

--- a/packages/google-dfes-types/src/version/base.ts
+++ b/packages/google-dfes-types/src/version/base.ts
@@ -1,7 +1,6 @@
+import { Locale } from '@google-dfes-types/constants';
+import { AnyCommand } from '@google-dfes-types/node';
 import { BaseModels } from '@voiceflow/base-types';
-
-import { Locale } from '@/constants';
-import { AnyCommand } from '@/node';
 
 export interface BasePrototype extends BaseModels.Version.Prototype<AnyCommand, Locale> {}
 

--- a/packages/google-dfes-types/tsconfig.build.json
+++ b/packages/google-dfes-types/tsconfig.build.json
@@ -2,15 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@google-dfes-types/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": [
-    "node_modules/**",
-    "build/**",
-    "tests/**"
+  "include": [
+    "src/**/*",
+    "typings/**/*"
   ]
 }

--- a/packages/google-dfes-types/tsconfig.json
+++ b/packages/google-dfes-types/tsconfig.json
@@ -1,12 +1,57 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      "@voiceflow/common": [
+        "common/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@voiceflow/base-types": [
+        "base-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@base-types/*": [
+        "base-types/src/*"
+      ],
+      "@voiceflow/chat-types": [
+        "chat-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@chat-types/*": [
+        "chat-types/src/*"
+      ],
+      "@voiceflow/voice-types": [
+        "voice-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@voice-types/*": [
+        "voice-types/src/*"
+      ],
+      "@voiceflow/voiceflow-types": [
+        "voiceflow-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@voiceflow-types/*": [
+        "voiceflow-types/src/*"
+      ],
+      "@voiceflow/google-types": [
+        "google-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@google-types/*": [
+        "google-types/src/*"
+      ],
+      "@google-dfes-types/*": [
+        "google-dfes-types/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/google-types/package.json
+++ b/packages/google-types/package.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.10.0",
-    "@voiceflow/chat-types": "^2.4.0",
-    "@voiceflow/common": "^7.19.0",
-    "@voiceflow/voice-types": "^2.3.0",
-    "@voiceflow/voiceflow-types": "^3.4.0",
+    "@voiceflow/base-types": "2.10.0",
+    "@voiceflow/chat-types": "2.4.0",
+    "@voiceflow/common": "7.19.0",
+    "@voiceflow/voice-types": "2.3.0",
+    "@voiceflow/voiceflow-types": "3.4.0",
     "googleapis": "92.0.0"
   },
   "files": [

--- a/packages/google-types/src/node/buttons/voice.ts
+++ b/packages/google-types/src/node/buttons/voice.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@google-types/constants';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface VoiceStepData extends VoiceNode.Buttons.StepData<Voice> {}
 

--- a/packages/google-types/src/node/capture/voice.ts
+++ b/packages/google-types/src/node/capture/voice.ts
@@ -1,7 +1,6 @@
+import { Voice } from '@google-types/constants';
 import { BaseButton } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 import { SharedNode } from './base';
 

--- a/packages/google-types/src/node/captureV2/voice.ts
+++ b/packages/google-types/src/node/captureV2/voice.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@google-types/constants';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface VoiceStepData extends VoiceNode.CaptureV2.StepData<Voice> {}
 

--- a/packages/google-types/src/node/interaction/voice.ts
+++ b/packages/google-types/src/node/interaction/voice.ts
@@ -1,7 +1,6 @@
+import { Voice } from '@google-types/constants';
 import { BaseButton } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 import { SharedNode } from './base';
 

--- a/packages/google-types/src/node/prompt/voice.ts
+++ b/packages/google-types/src/node/prompt/voice.ts
@@ -1,7 +1,6 @@
+import { Voice } from '@google-types/constants';
 import { BaseButton } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface VoiceStepData extends VoiceNode.Prompt.StepData<Voice>, BaseButton.StepButton {}
 

--- a/packages/google-types/src/node/speak/voice.ts
+++ b/packages/google-types/src/node/speak/voice.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@google-types/constants';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface VoiceStepData extends VoiceNode.Speak.StepData<Voice> {}
 

--- a/packages/google-types/src/utils/node.ts
+++ b/packages/google-types/src/utils/node.ts
@@ -1,6 +1,5 @@
+import * as Node from '@google-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isSpeak = BaseUtils.node.createNodeTypeguard<Node.Speak.Node>(BaseNode.NodeType.SPEAK);
 export const isStream = BaseUtils.node.createNodeTypeguard<Node.Stream.Node>(BaseNode.NodeType.STREAM);

--- a/packages/google-types/src/utils/step.ts
+++ b/packages/google-types/src/utils/step.ts
@@ -1,6 +1,5 @@
+import * as Node from '@google-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isSpeak = BaseUtils.step.createStepTypeguard<Node.Speak.Step>(BaseNode.NodeType.SPEAK);
 export const isPrompt = BaseUtils.step.createStepTypeguard<Node.Prompt.Step>(BaseNode.NodeType.PROMPT);

--- a/packages/google-types/src/utils/voice.ts
+++ b/packages/google-types/src/utils/voice.ts
@@ -6,7 +6,7 @@ import {
   VoiceLanguageCode,
   VoiceLanguageCodeToVoice,
   VoiceType,
-} from '@/constants';
+} from '@google-types/constants';
 
 export const getVoiceForLanguage = (language: Language, voiceType: VoiceType): GoogleVoice[][] => {
   const locales = LanguageToLocale[language];

--- a/packages/google-types/src/version/base/index.ts
+++ b/packages/google-types/src/version/base/index.ts
@@ -1,7 +1,6 @@
+import { Locale } from '@google-types/constants';
+import { AnyCommand } from '@google-types/node';
 import { BaseModels, DeepPartialByKey } from '@voiceflow/base-types';
-
-import { Locale } from '@/constants';
-import { AnyCommand } from '@/node';
 
 import { defaultSharedBasePublishing, SharedBasePublishing } from './publishing';
 

--- a/packages/google-types/src/version/base/publishing.ts
+++ b/packages/google-types/src/version/base/publishing.ts
@@ -1,4 +1,4 @@
-import { Category, Locale } from '@/constants';
+import { Category, Locale } from '@google-types/constants';
 
 // shared across google and dfes types
 export interface SharedBasePublishing {

--- a/packages/google-types/src/version/voice/index.ts
+++ b/packages/google-types/src/version/voice/index.ts
@@ -1,7 +1,6 @@
+import { Voice } from '@google-types/constants';
 import { DeepPartialByKey } from '@voiceflow/base-types';
 import { VoiceVersion } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 import { BasePrototype, defaultSharedBasePlatformData, SharedBasePlatformData } from '../base';
 import { defaultSharedVoicePublishing, defaultVoicePublishing, SharedVoicePublishing, VoicePublishing } from './publishing';

--- a/packages/google-types/src/version/voice/settings.ts
+++ b/packages/google-types/src/version/voice/settings.ts
@@ -1,6 +1,5 @@
+import { Voice } from '@google-types/constants';
 import { VoiceVersion } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
 
 export interface SharedVoiceSettings extends VoiceVersion.Settings<Voice> {}
 

--- a/packages/google-types/tsconfig.build.json
+++ b/packages/google-types/tsconfig.build.json
@@ -2,15 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@google-types/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": [
-    "node_modules/**",
-    "build/**",
-    "tests/**"
+  "include": [
+    "src/**/*",
+    "typings/**/*"
   ]
 }

--- a/packages/google-types/tsconfig.json
+++ b/packages/google-types/tsconfig.json
@@ -1,12 +1,43 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      "@voiceflow/common": [
+        "common/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@voiceflow/base-types": [
+        "base-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@base-types/*": [
+        "base-types/src/*"
+      ],
+      "@voiceflow/voice-types": [
+        "voice-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@voice-types/*": [
+        "voice-types/src/*"
+      ],
+      "@voiceflow/voiceflow-types": [
+        "voiceflow-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@voiceflow-types/*": [
+        "voiceflow-types/src/*"
+      ],
+      "@google-types/*": [
+        "google-types/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/metrics/src/testing/MetricsAsserter.ts
+++ b/packages/metrics/src/testing/MetricsAsserter.ts
@@ -1,11 +1,10 @@
 /* eslint-disable max-classes-per-file */
 
+import type { Metrics as BaseMetrics } from '@metrics/client';
 import axios from 'axios';
 import { expect } from 'chai';
 import { setTimeout as sleep } from 'timers/promises';
 import types from 'util/types';
-
-import type { Metrics as BaseMetrics } from '@/client';
 
 import { BaseConfig, createBaseConfig } from './createBaseConfig';
 

--- a/packages/metrics/tests/client/index.unit.ts
+++ b/packages/metrics/tests/client/index.unit.ts
@@ -1,5 +1,5 @@
-import MetricsClient from '@/client';
-import * as VFMetrics from '@/index';
+import MetricsClient from '@metrics/client';
+import * as VFMetrics from '@metrics/index';
 
 const metricsAsserter = new VFMetrics.Testing.MetricsAsserter(MetricsClient);
 

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -1,17 +1,17 @@
 {
   "compilerOptions": {
     // Compiler options
-    "lib": ["es2021"],
+    "lib": [
+      "es2021"
+    ],
     "module": "commonjs",
     "target": "es2021",
     "experimentalDecorators": true,
     "skipLibCheck": true,
-
     // Output options
     "outDir": "./build",
     "declaration": true,
     "sourceMap": true,
-
     // Strictness checks
     "strict": true,
     "noUnusedLocals": true,
@@ -19,16 +19,23 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
-
     // Imports
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "baseUrl": "./src",
     "paths": {
-      "@/*": ["./*"]
+      "@metrics/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["src", "typings", "tests"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src",
+    "typings",
+    "tests"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/voice-types/package.json
+++ b/packages/voice-types/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.10.0"
+    "@voiceflow/base-types": "2.10.0"
   },
   "files": [
     "build"

--- a/packages/voice-types/src/node/captureV2.ts
+++ b/packages/voice-types/src/node/captureV2.ts
@@ -1,6 +1,5 @@
+import { Intent } from '@voice-types/models';
 import { BaseNode, Nullable } from '@voiceflow/base-types';
-
-import { Intent } from '@/models';
 
 import { NodeNoMatch, NodeNoReply, StepNoMatch, StepNoReply } from './utils';
 

--- a/packages/voice-types/src/node/speak.ts
+++ b/packages/voice-types/src/node/speak.ts
@@ -1,6 +1,5 @@
+import { Prompt } from '@voice-types/models';
 import { BaseNode } from '@voiceflow/base-types';
-
-import { Prompt } from '@/models';
 
 export interface StepData<Voice> extends BaseNode.Speak.StepData, BaseNode.Speak.StepDataDialog<Prompt<Voice>> {}
 

--- a/packages/voice-types/src/node/utils.ts
+++ b/packages/voice-types/src/node/utils.ts
@@ -1,6 +1,5 @@
+import { Prompt } from '@voice-types/models';
 import { BaseNode, Nullable } from '@voiceflow/base-types';
-
-import { Prompt } from '@/models';
 
 export interface StepNoReply<Voice> extends BaseNode.Utils.StepNoReply<Prompt<Voice>> {}
 

--- a/packages/voice-types/src/utils/node.ts
+++ b/packages/voice-types/src/utils/node.ts
@@ -1,6 +1,5 @@
+import * as Node from '@voice-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isSpeak = BaseUtils.node.createNodeTypeguard<Node.Speak.Node>(BaseNode.NodeType.SPEAK);
 export const isCapture = BaseUtils.node.createNodeTypeguard<Node.Capture.Node>(BaseNode.NodeType.CAPTURE);

--- a/packages/voice-types/src/utils/prompt.ts
+++ b/packages/voice-types/src/utils/prompt.ts
@@ -1,6 +1,5 @@
+import { Prompt } from '@voice-types/models';
 import { Nullable } from '@voiceflow/base-types';
-
-import { Prompt } from '@/models';
 
 export const defaultPrompt = <V>(prompt: Nullable<Prompt<V>> | undefined, defaultVoice: V): Nullable<Prompt<V>> => {
   if (!prompt?.content) {

--- a/packages/voice-types/src/utils/step.ts
+++ b/packages/voice-types/src/utils/step.ts
@@ -1,6 +1,5 @@
+import * as Node from '@voice-types/node';
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
 
 export const isSpeak = BaseUtils.step.createStepTypeguard<Node.Speak.Step>(BaseNode.NodeType.SPEAK);
 export const isPrompt = BaseUtils.step.createStepTypeguard<Node.Prompt.Step>(BaseNode.NodeType.PROMPT);

--- a/packages/voice-types/src/version/index.ts
+++ b/packages/voice-types/src/version/index.ts
@@ -1,6 +1,5 @@
+import { Intent, Prompt } from '@voice-types/models';
 import { BaseModels, BaseVersion, DeepPartialByKey } from '@voiceflow/base-types';
-
-import { Intent, Prompt } from '@/models';
 
 import { defaultSettings, DefaultSettingsParams, Settings } from './settings';
 

--- a/packages/voice-types/src/version/settings.ts
+++ b/packages/voice-types/src/version/settings.ts
@@ -1,7 +1,6 @@
+import { Prompt } from '@voice-types/models';
+import { prompt } from '@voice-types/utils';
 import { BaseVersion, Nullable } from '@voiceflow/base-types';
-
-import { Prompt } from '@/models';
-import { prompt } from '@/utils';
 
 export interface Settings<Voice> extends BaseVersion.Settings<Prompt<Voice>> {
   session: BaseVersion.Session<Prompt<Voice>>;

--- a/packages/voice-types/tsconfig.build.json
+++ b/packages/voice-types/tsconfig.build.json
@@ -2,15 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@voice-types/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": [
-    "node_modules/**",
-    "build/**",
-    "tests/**"
+  "include": [
+    "src/**/*",
+    "typings/**/*"
   ]
 }

--- a/packages/voice-types/tsconfig.json
+++ b/packages/voice-types/tsconfig.json
@@ -1,12 +1,26 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@voiceflow/base-types": [
+        "base-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@base-types/*": [
+        "base-types/src/*"
+      ],
+      "@voice-types/*": [
+        "voice-types/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }

--- a/packages/voiceflow-types/package.json
+++ b/packages/voiceflow-types/package.json
@@ -7,9 +7,9 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.10.0",
-    "@voiceflow/chat-types": "^2.4.0",
-    "@voiceflow/voice-types": "^2.3.0"
+    "@voiceflow/base-types": "2.10.0",
+    "@voiceflow/chat-types": "2.4.0",
+    "@voiceflow/voice-types": "2.3.0"
   },
   "files": [
     "build"

--- a/packages/voiceflow-types/src/models.ts
+++ b/packages/voiceflow-types/src/models.ts
@@ -1,6 +1,6 @@
-import { Diagram } from '@/diagram';
-import { Project } from '@/project';
-import { Version } from '@/version';
+import { Diagram } from '@voiceflow-types/diagram';
+import { Project } from '@voiceflow-types/project';
+import { Version } from '@voiceflow-types/version';
 
 export interface VF {
   project: Project;

--- a/packages/voiceflow-types/src/node/buttons/voice.ts
+++ b/packages/voiceflow-types/src/node/buttons/voice.ts
@@ -1,6 +1,5 @@
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 export interface VoiceStepData extends VoiceNode.Buttons.StepData<Voice> {}
 

--- a/packages/voiceflow-types/src/node/capture/voice.ts
+++ b/packages/voiceflow-types/src/node/capture/voice.ts
@@ -1,7 +1,6 @@
 import { BaseButton, BaseRequest } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 /** @deprecated */
 export interface VoiceStepData extends VoiceNode.Capture.StepData<Voice>, BaseButton.StepButton {}

--- a/packages/voiceflow-types/src/node/captureV2/voice.ts
+++ b/packages/voiceflow-types/src/node/captureV2/voice.ts
@@ -1,7 +1,6 @@
 import { BaseButton, BaseRequest } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 export interface VoiceStepData extends VoiceNode.CaptureV2.StepData<Voice>, BaseButton.StepButton {}
 

--- a/packages/voiceflow-types/src/node/interaction/voice.ts
+++ b/packages/voiceflow-types/src/node/interaction/voice.ts
@@ -1,7 +1,6 @@
 import { BaseButton, BaseNode, BaseRequest } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 export interface VoiceStepData extends VoiceNode.Interaction.StepData<Voice>, BaseButton.StepButton {}
 

--- a/packages/voiceflow-types/src/node/prompt/voice.ts
+++ b/packages/voiceflow-types/src/node/prompt/voice.ts
@@ -1,7 +1,6 @@
 import { BaseButton } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 export interface VoiceStepData extends VoiceNode.Prompt.StepData<Voice>, BaseButton.StepButton {}
 

--- a/packages/voiceflow-types/src/node/speak/voice.ts
+++ b/packages/voiceflow-types/src/node/speak/voice.ts
@@ -1,6 +1,5 @@
 import { VoiceNode } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 export interface VoiceStepData extends VoiceNode.Speak.StepData<Voice> {}
 

--- a/packages/voiceflow-types/src/project/chat/index.ts
+++ b/packages/voiceflow-types/src/project/chat/index.ts
@@ -1,6 +1,5 @@
 import { ChatProject } from '@voiceflow/chat-types';
-
-import { PlatformType, ProjectType } from '@/constants';
+import { PlatformType, ProjectType } from '@voiceflow-types/constants';
 
 import { ChatMemberPlatformData } from './member';
 

--- a/packages/voiceflow-types/src/project/index.ts
+++ b/packages/voiceflow-types/src/project/index.ts
@@ -1,4 +1,4 @@
-import { ProjectType } from '@/constants';
+import { ProjectType } from '@voiceflow-types/constants';
 
 import { ChatMemberPlatformData, ChatPlatformData, ChatProject, defaultChatMemberPlatformData, defaultChatPlatformData } from './chat';
 import { defaultVoiceMemberPlatformData, defaultVoicePlatformData, VoiceMemberPlatformData, VoicePlatformData, VoiceProject } from './voice';

--- a/packages/voiceflow-types/src/project/voice/index.ts
+++ b/packages/voiceflow-types/src/project/voice/index.ts
@@ -1,6 +1,5 @@
 import { VoiceProject } from '@voiceflow/voice-types';
-
-import { PlatformType, ProjectType } from '@/constants';
+import { PlatformType, ProjectType } from '@voiceflow-types/constants';
 
 import { VoiceMemberPlatformData } from './member';
 

--- a/packages/voiceflow-types/src/utils/node.ts
+++ b/packages/voiceflow-types/src/utils/node.ts
@@ -1,6 +1,5 @@
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
+import * as Node from '@voiceflow-types/node';
 
 export const isSpeak = BaseUtils.node.createNodeTypeguard<Node.Speak.Node>(BaseNode.NodeType.SPEAK);
 export const isCapture = BaseUtils.node.createNodeTypeguard<Node.Capture.Node>(BaseNode.NodeType.CAPTURE);

--- a/packages/voiceflow-types/src/utils/step.ts
+++ b/packages/voiceflow-types/src/utils/step.ts
@@ -1,6 +1,5 @@
 import { BaseNode, BaseUtils } from '@voiceflow/base-types';
-
-import * as Node from '@/node';
+import * as Node from '@voiceflow-types/node';
 
 export const isSpeak = BaseUtils.step.createStepTypeguard<Node.Speak.Step>(BaseNode.NodeType.SPEAK);
 export const isPrompt = BaseUtils.step.createStepTypeguard<Node.Prompt.Step>(BaseNode.NodeType.PROMPT);

--- a/packages/voiceflow-types/src/version/base.ts
+++ b/packages/voiceflow-types/src/version/base.ts
@@ -1,7 +1,6 @@
 import { BaseModels } from '@voiceflow/base-types';
-
-import { Locale } from '@/constants';
-import { AnyCommand } from '@/node';
+import { Locale } from '@voiceflow-types/constants';
+import { AnyCommand } from '@voiceflow-types/node';
 
 // shared only across voiceflow types
 export interface BasePrototype extends BaseModels.Version.Prototype<AnyCommand, Locale> {}

--- a/packages/voiceflow-types/src/version/index.ts
+++ b/packages/voiceflow-types/src/version/index.ts
@@ -1,6 +1,5 @@
 import { DeepPartialByKey } from '@voiceflow/base-types';
-
-import { ProjectType } from '@/constants';
+import { ProjectType } from '@voiceflow-types/constants';
 
 import { SupportedProjectType } from '../project';
 import { ChatPlatformData, ChatSettings, ChatVersion, defaultChatPlatformData, defaultChatSettings } from './chat';

--- a/packages/voiceflow-types/src/version/voice/index.ts
+++ b/packages/voiceflow-types/src/version/voice/index.ts
@@ -1,7 +1,6 @@
 import { DeepPartialByKey } from '@voiceflow/base-types';
 import { VoiceVersion } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 import { BasePrototype } from '../base';
 import { defaultSharedVoiceSettings, defaultVoiceSettings, SharedVoiceSettings, VoiceSettings } from './settings';

--- a/packages/voiceflow-types/src/version/voice/settings.ts
+++ b/packages/voiceflow-types/src/version/voice/settings.ts
@@ -1,6 +1,5 @@
 import { VoiceVersion } from '@voiceflow/voice-types';
-
-import { Voice } from '@/constants';
+import { Voice } from '@voiceflow-types/constants';
 
 import { BaseSettings, defaultBaseSettings } from '../base';
 

--- a/packages/voiceflow-types/tsconfig.build.json
+++ b/packages/voiceflow-types/tsconfig.build.json
@@ -2,15 +2,22 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "build/common",
+    "paths": {
+      "@voiceflow-types/*": [
+        "src/*"
+      ]
+    },
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"
       }
     ]
   },
-  "exclude": [
-    "node_modules/**",
-    "build/**",
-    "tests/**"
+  "include": [
+    "src/**/*",
+    "typings/**/*"
   ]
 }

--- a/packages/voiceflow-types/tsconfig.json
+++ b/packages/voiceflow-types/tsconfig.json
@@ -1,12 +1,40 @@
 {
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
-    "outDir": "./build/common",
-    "baseUrl": "./src",
+    "baseUrl": "..",
     "paths": {
-      "@/*": ["./*"]
+      // only used to fix intra-monorepo resolution
+      "@common/*": [
+        "common/src/*"
+      ],
+      "@voiceflow/base-types": [
+        "base-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@base-types/*": [
+        "base-types/src/*"
+      ],
+      "@voiceflow/chat-types": [
+        "chat-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@chat-types/*": [
+        "chat-types/src/*"
+      ],
+      "@voiceflow/voice-types": [
+        "voice-types/src"
+      ],
+      // only used to fix intra-monorepo resolution
+      "@voice-types/*": [
+        "voice-types/src/*"
+      ],
+      "@voiceflow-types/*": [
+        "voiceflow-types/src/*"
+      ]
     }
   },
-  "compileOnSave": false,
-  "exclude": ["node_modules/**", "build/**"]
+  "exclude": [
+    "node_modules/**/*",
+    "build/**/*"
+  ]
 }


### PR DESCRIPTION
* make the types work (`yarn build` works locally with a `lerna`-linked monorepo)

1. made sure every package in the monorepo depended on exact versions of each other
2. updated each `tsconfig.json` to enforce a unique path alias per package
3. updated each `tsconfig.json` to include transient path aliases to make sure linked, intra-package type resolution resolves nicely in IDEs
4. updated each `tsconfig.build.json` to override the local path alias at build time (to enforce isolation for built package, packages should only ever refer to each others main file)