### PR TITLE
[Merged by Bors] - fix: make all packages public on npm registry (VF-000)

### DIFF
--- a/packages/alexa-types/package.json
+++ b/packages/alexa-types/package.json
@@ -24,6 +24,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -38,6 +38,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/base-types/package.json
+++ b/packages/base-types/package.json
@@ -21,6 +21,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -20,6 +20,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -50,6 +50,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/google-dfes-types/package.json
+++ b/packages/google-dfes-types/package.json
@@ -25,6 +25,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/google-types/package.json
+++ b/packages/google-types/package.json
@@ -25,6 +25,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/voice-types/package.json
+++ b/packages/voice-types/package.json
@@ -20,6 +20,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"

--- a/packages/voiceflow-types/package.json
+++ b/packages/voiceflow-types/package.json
@@ -22,6 +22,9 @@
   "license": "ISC",
   "main": "build/common/index.js",
   "module": "build/esm/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/voiceflow/libs.git"


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

explicitly define

```json
"publishConfig": {
  "access": "public"
}
```

so that all packages are published as public.
seems to only be an issue for `@voiceflow/voiceflow-types` atm but it's nice to have a consistent config for all the packages.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written