### PR TITLE
[Merged by Bors] - feat: Add variableState to api-sdk and to base-types (VF-2609)

### DIFF
--- a/packages/api-sdk/src/resources/index.ts
+++ b/packages/api-sdk/src/resources/index.ts
@@ -5,4 +5,5 @@ export { default as Program } from './program';
 export { default as Project } from './project';
 export { default as PrototypeProgram } from './prototypeProgram';
 export { default as User } from './user';
+export { default as VariableState } from './variableState';
 export { default as Version } from './version';

--- a/packages/api-sdk/src/resources/variableState.ts
+++ b/packages/api-sdk/src/resources/variableState.ts
@@ -1,0 +1,27 @@
+import Fetch from '@api-sdk/fetch';
+import { BaseModels } from '@voiceflow/base-types';
+
+import { Fields } from './base';
+import CrudResource from './crud';
+
+export const ENDPOINT = 'variable-states';
+
+export type ModelKey = '_id';
+
+class VariableStateResource extends CrudResource<BaseModels.VariableState.Model, ModelKey, VariableStateResource, 'projectID' | 'name'> {
+  constructor(fetch: Fetch) {
+    super({
+      fetch,
+      clazz: VariableStateResource,
+      endpoint: ENDPOINT,
+    });
+  }
+
+  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields: Fields): Promise<T>;
+
+  public async get(id: string, fields?: Fields): Promise<BaseModels.VariableState.Model> {
+    return fields ? super._getByID(id, fields) : super._getByID(id);
+  }
+}
+
+export default VariableStateResource;

--- a/packages/api-sdk/src/resources/variableState.ts
+++ b/packages/api-sdk/src/resources/variableState.ts
@@ -17,7 +17,7 @@ class VariableStateResource extends CrudResource<BaseModels.VariableState.Model,
     });
   }
 
-  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields: Fields): Promise<T>;
+  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields?: Fields): Promise<T>;
 
   public async get(id: string, fields?: Fields): Promise<BaseModels.VariableState.Model> {
     return fields ? super._getByID(id, fields) : super._getByID(id);

--- a/packages/api-sdk/src/resources/variableState.ts
+++ b/packages/api-sdk/src/resources/variableState.ts
@@ -17,7 +17,9 @@ class VariableStateResource extends CrudResource<BaseModels.VariableState.Model,
     });
   }
 
-  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields?: Fields): Promise<T>;
+  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields: Fields): Promise<T>;
+
+  public async get<T extends BaseModels.VariableState.Model = BaseModels.VariableState.Model>(id: string): Promise<T>;
 
   public async get(id: string, fields?: Fields): Promise<BaseModels.VariableState.Model> {
     return fields ? super._getByID(id, fields) : super._getByID(id);

--- a/packages/api-sdk/tests/resources/variableState.unit.ts
+++ b/packages/api-sdk/tests/resources/variableState.unit.ts
@@ -1,0 +1,71 @@
+/* eslint-disable dot-notation */
+import { VariableState } from '@api-sdk/resources';
+import Crud from '@api-sdk/resources/crud';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
+
+const createClient = () => {
+  const fetch = {
+    get: sinon.stub(),
+    post: sinon.stub(),
+    put: sinon.stub(),
+    patch: sinon.stub(),
+    delete: sinon.stub(),
+  };
+
+  const crud = {
+    get: sinon.stub(),
+    getByID: sinon.stub(),
+    post: sinon.stub(),
+    put: sinon.stub(),
+    patch: sinon.stub(),
+    delete: sinon.stub(),
+  };
+
+  Crud.prototype['_get'] = crud.get;
+  Crud.prototype['_getByID'] = crud.getByID;
+  Crud.prototype['_post'] = crud.post;
+  Crud.prototype['_put'] = crud.put;
+  Crud.prototype['_patch'] = crud.patch;
+  Crud.prototype['_delete'] = crud.delete;
+
+  const resource = new VariableState(fetch as any);
+
+  return {
+    crud,
+    fetch,
+    resource,
+  };
+};
+
+describe('VariableStateResource', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('.get', async () => {
+    const { crud, resource } = createClient();
+
+    crud.getByID.resolves(RESPONSE_DATA);
+
+    const data = await resource.get('1');
+
+    expect(crud.getByID.callCount).to.eql(1);
+    expect(crud.getByID.args[0]).to.eql(['1']);
+    expect(data).to.eql(RESPONSE_DATA);
+  });
+
+  it('.get fields', async () => {
+    const { crud, resource } = createClient();
+
+    crud.getByID.resolves(RESPONSE_DATA);
+
+    const data = await resource.get<{ name: string }>('1', ['name']);
+
+    expect(crud.getByID.callCount).to.eql(1);
+    expect(crud.getByID.args[0]).to.eql(['1', ['name']]);
+    expect(data).to.eql(RESPONSE_DATA);
+  });
+});

--- a/packages/base-types/src/index.ts
+++ b/packages/base-types/src/index.ts
@@ -17,3 +17,4 @@ export * as Utils from './utils';
 export * as BaseUtils from './utils';
 export * as Version from './version';
 export * as BaseVersion from './version';
+export * as VariableState from './version';

--- a/packages/base-types/src/models/index.ts
+++ b/packages/base-types/src/models/index.ts
@@ -4,4 +4,5 @@ export * as Diagram from './diagram';
 export * as Program from './program';
 export * as Project from './project';
 export * as Transcript from './transcripts';
+export * as VariableState from './variableState';
 export * as Version from './version';

--- a/packages/base-types/src/models/variableState.ts
+++ b/packages/base-types/src/models/variableState.ts
@@ -1,9 +1,14 @@
 export type VariableValue = string | boolean | number | null;
 
+export interface StartFrom {
+  diagramID: string;
+  stepID: string;
+}
+
 export interface Model {
   _id: string;
   name: string;
   projectID: string;
-  startFrom: { diagramID: string; stepID: string } | null;
+  startFrom: StartFrom | null;
   variables: Record<string, VariableValue>;
 }

--- a/packages/base-types/src/models/variableState.ts
+++ b/packages/base-types/src/models/variableState.ts
@@ -1,0 +1,9 @@
+export type VariableValue = string | boolean | number | null;
+
+export interface Model {
+  _id: string;
+  name: string;
+  projectID: string;
+  startFrom: { diagramID: string; stepID: string } | null;
+  variables: Record<string, VariableValue>;
+}

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -37,6 +37,7 @@ export interface PrototypeSettings {
   brandImage?: string;
   hasPassword?: boolean;
   buttonsOnly?: boolean;
+  variableStateID?: string;
 }
 
 export interface Prototype<Command extends BaseCommand = BaseCommand, Locale extends string = string> {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2609**

### Brief description. What is this change?

Adding variableState to base-types and api-sdk. This will be used to fetch a VariableState from the general service, so we can inject the VariableState data during the compilation and use it in the public prototype.