### PR TITLE
[Merged by Bors] - fix: expose variable state resource in api-sdk (VF-2609)

### DIFF
--- a/packages/api-sdk/src/publicclient.ts
+++ b/packages/api-sdk/src/publicclient.ts
@@ -1,5 +1,5 @@
 import Fetch, { FetchConfig } from '@api-sdk/fetch';
-import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, Version } from '@api-sdk/resources';
+import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, VariableState, Version } from '@api-sdk/resources';
 import { Crypto } from '@voiceflow/common';
 
 export interface ClientOptions {
@@ -27,6 +27,8 @@ export class PublicClient {
 
   public prototypeProgram: PrototypeProgram;
 
+  public variableState: VariableState;
+
   constructor({ clientKey, apiEndpoint, authorization, options, analyticsEncryption }: ClientOptions) {
     this.fetch = new Fetch({ clientKey, apiEndpoint, authorization, options });
 
@@ -37,5 +39,6 @@ export class PublicClient {
     this.diagram = new Diagram(this.fetch);
     this.analytics = new Analytics(this.fetch, { encryption: analyticsEncryption });
     this.prototypeProgram = new PrototypeProgram(this.fetch);
+    this.variableState = new VariableState(this.fetch);
   }
 }

--- a/packages/api-sdk/src/resources/variableState.ts
+++ b/packages/api-sdk/src/resources/variableState.ts
@@ -21,8 +21,6 @@ class VariableStateResource extends CrudResource<BaseModels.VariableState.Model,
 
   public async get<T extends BaseModels.VariableState.Model = BaseModels.VariableState.Model>(id: string): Promise<T>;
 
-  public async get<T extends BaseModels.VariableState.Model = BaseModels.VariableState.Model>(id: string): Promise<T>;
-
   public async get(id: string, fields?: Fields): Promise<BaseModels.VariableState.Model> {
     return fields ? super._getByID(id, fields) : super._getByID(id);
   }

--- a/packages/api-sdk/src/resources/variableState.ts
+++ b/packages/api-sdk/src/resources/variableState.ts
@@ -17,7 +17,9 @@ class VariableStateResource extends CrudResource<BaseModels.VariableState.Model,
     });
   }
 
-  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields?: Fields): Promise<T>;
+  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields: Fields): Promise<T>;
+
+  public async get<T extends BaseModels.VariableState.Model = BaseModels.VariableState.Model>(id: string): Promise<T>;
 
   public async get<T extends BaseModels.VariableState.Model = BaseModels.VariableState.Model>(id: string): Promise<T>;
 

--- a/packages/api-sdk/src/resources/variableState.ts
+++ b/packages/api-sdk/src/resources/variableState.ts
@@ -17,7 +17,7 @@ class VariableStateResource extends CrudResource<BaseModels.VariableState.Model,
     });
   }
 
-  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields: Fields): Promise<T>;
+  public async get<T extends Partial<BaseModels.VariableState.Model>>(id: string, fields?: Fields): Promise<T>;
 
   public async get<T extends BaseModels.VariableState.Model = BaseModels.VariableState.Model>(id: string): Promise<T>;
 

--- a/packages/api-sdk/tests/client.unit.ts
+++ b/packages/api-sdk/tests/client.unit.ts
@@ -1,10 +1,10 @@
 import { Client } from '@api-sdk/client';
 import Fetch from '@api-sdk/fetch';
-import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, User, Version } from '@api-sdk/resources';
+import { Analytics, APIKey, Diagram, Program, Project, PrototypeProgram, User, VariableState, Version } from '@api-sdk/resources';
 import { expect } from 'chai';
 import JWT from 'jsonwebtoken';
 
-const CLIENT_RESOURCES = [Fetch, Diagram, Program, Project, Version, User, APIKey, Analytics];
+const CLIENT_RESOURCES = [Fetch, Diagram, Program, Project, Version, User, APIKey, Analytics, VariableState];
 
 const USER_HASH = 'UserHash_16chars';
 const createClient = (authorization?: string) =>

--- a/packages/base-types/src/models/variableState.ts
+++ b/packages/base-types/src/models/variableState.ts
@@ -1,10 +1,8 @@
 export type VariableValue = string | boolean | number | null;
-
 export interface StartFrom {
   diagramID: string;
   stepID: string;
 }
-
 export interface Model {
   _id: string;
   name: string;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2609**

### Brief description. What is this change?
expose variable state as a resource. This specific endpoint will be used under general-service to consume variable state and inject variables and stepID into version.

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| general-service | [link](https://github.com/voiceflow/general-service/pull/271) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
