### PR TITLE
[Merged by Bors] - feat: addtional guards and helpers (VF-3049)

### DIFF
--- a/packages/voiceflow-types/src/constants/base.ts
+++ b/packages/voiceflow-types/src/constants/base.ts
@@ -111,6 +111,6 @@ export enum Language {
   TR = 'tr',
 }
 
-const LanguageValues = new Set(Object.values(Language));
+const LanguageValues: ReadonlySet<Language> = new Set(Object.values(Language));
 
 export const isVoiceflowLanguage = (lang: any): lang is Language => LanguageValues.has(lang);

--- a/packages/voiceflow-types/src/constants/base.ts
+++ b/packages/voiceflow-types/src/constants/base.ts
@@ -110,3 +110,7 @@ export enum Language {
   // Turkish
   TR = 'tr',
 }
+
+const LanguageValues = new Set(Object.values(Language));
+
+export const isVoiceflowLanguage = (lang: any): lang is Language => LanguageValues.has(lang);

--- a/packages/voiceflow-types/src/constants/intent.ts
+++ b/packages/voiceflow-types/src/constants/intent.ts
@@ -20,6 +20,9 @@ export interface DefaultIntent {
   samples: string[];
 }
 
+export const findDefaultIntent = (language: Language, name: string): DefaultIntent | undefined =>
+  DEFAULT_INTENTS_MAP?.[language]?.find((intent) => intent.name === name);
+
 export const DEFAULT_INTENTS_MAP: Record<string, DefaultIntent[]> = {
   // English (AU,CA,US,UK,IN)
   [Language.EN]: [


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3049**

### Brief description. What is this change?

Adds a set and guard to check the language.

Adds a helper to get a built-in via language and name.