### PR TITLE
[Merged by Bors] - fix(metrics): fix entrypoint (VF-000)

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -71,5 +71,6 @@
     "test:run": "NODE_ENV=test nyc ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.{unit,it}.ts'",
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
-  }
+  },
+  "types": "build/index.d.ts"
 }

--- a/packages/metrics/tsconfig.build.json
+++ b/packages/metrics/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "rootDir": "src",
-    "outDir": "build/common",
+    "outDir": "build",
     "plugins": [
       {
         "transform": "@zerollup/ts-transform-paths"


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

#208 accidentally changed the output folder from `./build/` to `./build/common/`.
this PR reverts that change.
it also explicitly sets the source for typings files (rather than letting `tsc` infer it from the entrypoint)

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written