### PR TITLE
[Merged by Bors] - feat(nestjs-timeout): create `@voiceflow/nestjs-timeout` package (VF-2950)

### DIFF
--- a/packages/nestjs-timeout/.depcheckrc
+++ b/packages/nestjs-timeout/.depcheckrc
@@ -1,0 +1,22 @@
+{
+  "specials": [
+    "bin",
+    "eslint",
+    "lint-staged",
+    "istanbul",
+    "commitizen",
+    "husky",
+    "prettier",
+    "ttypescript"
+  ],
+  "ignores": [
+    "@commitlint/*",
+    "@types/*",
+    "@voiceflow/commitlint-config",
+    "@voiceflow/git-branch-check",
+    "fixpack",
+    "husky",
+    "lint-staged",
+    "eslint-import-resolver-typescript"
+  ]
+}

--- a/packages/nestjs-timeout/.depcheckrc
+++ b/packages/nestjs-timeout/.depcheckrc
@@ -10,6 +10,7 @@
     "ttypescript"
   ],
   "ignores": [
+    "@nestjs-timeout/*",
     "@commitlint/*",
     "@types/*",
     "@voiceflow/commitlint-config",

--- a/packages/nestjs-timeout/.eslintignore
+++ b/packages/nestjs-timeout/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+build
+nyc_*
+.nyc_*

--- a/packages/nestjs-timeout/.eslintrc.js
+++ b/packages/nestjs-timeout/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: {
+    'no-underscore-dangle': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    'class-methods-use-this': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: true,
+      },
+    ],
+  },
+};

--- a/packages/nestjs-timeout/.nycrc.json
+++ b/packages/nestjs-timeout/.nycrc.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "include": [
+    "src/**"
+  ],
+  "reporter": [
+    "html",
+    "text",
+    "text-summary",
+    "lcov"
+  ],
+  "report-dir": "nyc_coverage",
+  "extension": [
+    ".ts"
+  ]
+}

--- a/packages/nestjs-timeout/README.md
+++ b/packages/nestjs-timeout/README.md
@@ -1,0 +1,23 @@
+# NestJS Timeout
+
+A NestJS interceptor that will error a request after a timeout is exceeded.
+
+## Installation
+
+```sh
+yarn add @voiceflow/nestjs-timeout
+```
+
+## Usage
+
+```ts
+import { Controller } from '@nestjs/common';
+import { TimeoutInterceptor } from '@voiceflow/nestjs-timeout';
+
+@Controller()
+// Timeout after 30 seconds
+@UseInterceptors(new TimeoutInterceptor(30 * 1000))
+export class MyController {
+  /* ... */
+}
+```

--- a/packages/nestjs-timeout/config/tests/mocharc.yml
+++ b/packages/nestjs-timeout/config/tests/mocharc.yml
@@ -1,0 +1,18 @@
+require:
+  - source-map-support/register
+
+timeout: 4000
+exit: true
+recursive: true
+
+watchFiles:
+  - test/**/*
+  - src/**/*
+watchExtensions:
+  - js
+  - jsx
+  - ts
+  - tsx
+
+spec:
+  - tests/setup.ts

--- a/packages/nestjs-timeout/package.json
+++ b/packages/nestjs-timeout/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@voiceflow/nestjs-timeout",
+  "description": "A NestJS interceptor that will error a request after a timeout is exceeded.",
+  "version": "1.0.0",
+  "author": "Voiceflow",
+  "bugs": {
+    "url": "https://github.com/voiceflow/libs/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@nestjs/common": "8.0.0",
+    "@types/chai": "4.3.0",
+    "@types/chai-as-promised": "^7.1.4",
+    "@types/mocha": "^8.2.2",
+    "@types/node": "16.11.12",
+    "@zerollup/ts-transform-paths": "^1.7.18",
+    "chai": "4.3.6",
+    "chai-as-promised": "^7.1.1",
+    "depcheck": "^1.4.1",
+    "lint-staged": "^11.0.0",
+    "mocha": "9.1.3",
+    "nyc": "^15.1.0",
+    "reflect-metadata": "0.1.13",
+    "rimraf": "^3.0.2",
+    "rxjs": "7.0.0",
+    "ts-mocha": "^8.0.0",
+    "ts-node": "10.5.0",
+    "tsconfig-paths": "3.12.0",
+    "ttypescript": "1.5.13",
+    "typescript": "4.6.2"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^8.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.0.0"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "files": [
+    "build/"
+  ],
+  "homepage": "https://github.com/voiceflow/libs#readme",
+  "keywords": [
+    "nestjs",
+    "timeout",
+    "http",
+    "voiceflow"
+  ],
+  "license": "ISC",
+  "main": "build/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voiceflow/libs.git"
+  },
+  "scripts": {
+    "build": "ttsc --project ./tsconfig.build.json",
+    "clean": "rimraf build",
+    "commit": "cz",
+    "lint": "eslint \"**/*.{js,ts}\"",
+    "lint:fix": "yarn lint --fix",
+    "lint:quiet": "yarn lint --quiet",
+    "lint:report": "eslint-output --quiet \"**/*.{js,ts}\"",
+    "prebuild": "yarn clean",
+    "tdd": "yarn test --watch",
+    "test": "yarn test:run",
+    "test:dependencies": "depcheck",
+    "test:integration": "NODE_ENV=test nyc --report-dir nyc_coverage_integration ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.it.ts'",
+    "test:run": "NODE_ENV=test nyc ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.{unit,it}.ts'",
+    "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
+    "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
+  },
+  "types": "build/index.d.ts"
+}

--- a/packages/nestjs-timeout/sonar-project.properties
+++ b/packages/nestjs-timeout/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectName=libs-common
+sonar.sources=src
+sonar.tests=tests
+sonar.eslint.reportPaths=sonar/report.json
+sonar.typescript.tsconfigPath=./tsconfig.json
+sonar.javascript.lcov.reportPaths=nyc_coverage_unit/lcov.info,nyc_coverage_integration/lcov.info

--- a/packages/nestjs-timeout/src/index.ts
+++ b/packages/nestjs-timeout/src/index.ts
@@ -1,0 +1,2 @@
+export { TimeoutInterceptor } from './timeout/timeout.interceptor';
+export { TimeoutModule } from './timeout/timeout.module';

--- a/packages/nestjs-timeout/src/timeout/timeout.interceptor.ts
+++ b/packages/nestjs-timeout/src/timeout/timeout.interceptor.ts
@@ -1,0 +1,27 @@
+import { CallHandler, ExecutionContext, InternalServerErrorException, NestInterceptor } from '@nestjs/common';
+import { Observable, throwError, TimeoutError } from 'rxjs';
+import { catchError, timeout } from 'rxjs/operators';
+
+/**
+ * An interceptor that throws an error if a request takes longer than the provided timeout.
+ */
+// Adapted from https://stackoverflow.com/a/66852766/10808983
+export class TimeoutInterceptor<T> implements NestInterceptor {
+  /**
+   * Create a new {@link TimeoutInterceptor}.
+   * @param timeoutMs - The number of milliseconds before a request times out
+   */
+  constructor(private readonly timeoutMs: number) {}
+
+  intercept(_context: ExecutionContext, next: CallHandler<T>): Observable<T> {
+    return next.handle().pipe(
+      timeout(this.timeoutMs),
+      catchError((err: unknown): Observable<never> => {
+        if (err instanceof TimeoutError) {
+          return throwError(() => new InternalServerErrorException('The server timed out'));
+        }
+        return throwError(() => err);
+      })
+    );
+  }
+}

--- a/packages/nestjs-timeout/src/timeout/timeout.module.ts
+++ b/packages/nestjs-timeout/src/timeout/timeout.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { TimeoutInterceptor } from './timeout.interceptor';
+
+@Module({
+  providers: [TimeoutInterceptor],
+  exports: [TimeoutInterceptor],
+})
+export class TimeoutModule {}

--- a/packages/nestjs-timeout/tests/index.unit.ts
+++ b/packages/nestjs-timeout/tests/index.unit.ts
@@ -1,0 +1,14 @@
+import * as pkg from '@nestjs-timeout/index';
+import { TimeoutInterceptor } from '@nestjs-timeout/timeout/timeout.interceptor';
+import { TimeoutModule } from '@nestjs-timeout/timeout/timeout.module';
+import { expect } from 'chai';
+
+describe('index', () => {
+  it('should export TimeoutModule', () => {
+    expect(pkg.TimeoutModule).to.eq(TimeoutModule);
+  });
+
+  it('should export TimeoutInterceptor', () => {
+    expect(pkg.TimeoutInterceptor).to.eq(TimeoutInterceptor);
+  });
+});

--- a/packages/nestjs-timeout/tests/setup.ts
+++ b/packages/nestjs-timeout/tests/setup.ts
@@ -1,0 +1,4 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);

--- a/packages/nestjs-timeout/tests/timeout/timeout.interceptor.unit.ts
+++ b/packages/nestjs-timeout/tests/timeout/timeout.interceptor.unit.ts
@@ -1,0 +1,8 @@
+import { TimeoutInterceptor } from '@nestjs-timeout/timeout/timeout.interceptor';
+import { expect } from 'chai';
+
+describe('TimeoutInterceptor', () => {
+  it('should be defined', () => {
+    expect(() => new TimeoutInterceptor(5000)).not.to.throw();
+  });
+});

--- a/packages/nestjs-timeout/tests/timeout/timeout.module.unit.ts
+++ b/packages/nestjs-timeout/tests/timeout/timeout.module.unit.ts
@@ -1,0 +1,8 @@
+import { TimeoutModule } from '@nestjs-timeout/timeout/timeout.module';
+import { expect } from 'chai';
+
+describe('TimeoutModule', () => {
+  it('should be defined', () => {
+    expect(() => new TimeoutModule()).not.to.throw();
+  });
+});

--- a/packages/nestjs-timeout/tsconfig.build.json
+++ b/packages/nestjs-timeout/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "build",
+    "plugins": [
+      {
+        "transform": "@zerollup/ts-transform-paths"
+      }
+    ],
+    "traceResolution": false,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src", "typings"]
+}

--- a/packages/nestjs-timeout/tsconfig.json
+++ b/packages/nestjs-timeout/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "extends": "@voiceflow/tsconfig",
+  "compilerOptions": {
+    // General
+    "target": "es2021",
+    "module": "commonjs",
+    "lib": ["es2021"],
+    "experimentalDecorators": true,
+    "baseUrl": "./",
+    "paths": {
+      "@nestjs-timeout/*": ["src/*"]
+    },
+
+    // Strictness
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Modules
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+
+    // Emit
+    "outDir": "./build",
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "sourceMap": true
+  },
+  "include": ["src", "tests", "typings"],
+  "exclude": ["**/node_modules", "**/.*/"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,21 +1911,6 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
-
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -7449,28 +7434,7 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,16 @@
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz#b72a37c654e598f9ae6f8335faaee182bebc6b28"
   integrity sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==
 
+"@nestjs/common@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-8.0.0.tgz#b87499cb6cd9ff0313a247da70ea5c5a16011fd7"
+  integrity sha512-qztj56rJRFnNPfz/ddCu2TkSwEHTpm0wi9xydyEfHk8b7QM10ZwkHoM2Of/qWxDkh3qDu8fscdxo7w1ix+EKFA==
+  dependencies:
+    axios "0.21.1"
+    iterare "1.2.1"
+    tslib "2.3.0"
+    uuid "8.3.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1445,7 +1455,7 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*", "@types/chai@^4.2.11", "@types/chai@^4.2.19", "@types/chai@^4.3.0":
+"@types/chai@*", "@types/chai@4.3.0", "@types/chai@^4.2.11", "@types/chai@^4.2.19", "@types/chai@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
   integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
@@ -1901,6 +1911,21 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -2113,6 +2138,13 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios@0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axios@0.24.0:
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
@@ -2324,7 +2356,7 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
-chai@^4.2.0, chai@^4.3.4:
+chai@4.3.6, chai@^4.2.0, chai@^4.3.4:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
   integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
@@ -3852,6 +3884,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
+follow-redirects@^1.10.0:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+
 follow-redirects@^1.14.4:
   version "1.14.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
@@ -4915,6 +4952,11 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterare@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/iterare/-/iterare-1.2.1.tgz#139c400ff7363690e33abffa33cbba8920f00042"
+  integrity sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6782,6 +6824,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+reflect-metadata@0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -6963,6 +7010,13 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.0.0.tgz#c55d67c52aee8804d32ab60965e335bd41e2dc2d"
+  integrity sha512-I1V/ArAtGJg4kmCfms8fULm0SwYgEsAf2d5WPCBGzTYm2qTjO3Tx4EDFaGjbOox8CeEsC69jQK22mnmfyA26sw==
+  dependencies:
+    tslib "~2.1.0"
 
 rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.7"
@@ -7395,7 +7449,28 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7679,6 +7754,11 @@ tsconfig-paths@3.12.0, tsconfig-paths@^3.12.0, tsconfig-paths@^3.5.0, tsconfig-p
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -7688,6 +7768,11 @@ tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -7779,6 +7864,11 @@ typescript@4.4.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
+typescript@4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
 typescript@^4.4.3:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
@@ -7867,15 +7957,15 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
+uuid@8.3.2, uuid@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.0.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
**Fixes or implements VF-2950**

### Brief description. What is this change?

creates a reusable package for timing out requests in nestjs

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written