### PR TITLE
[Merged by Bors] - refactor(nestjs-timeout): use stricter types in TimeoutInterceptor (VF-000)

### DIFF
--- a/packages/nestjs-timeout/src/timeout/timeout.interceptor.ts
+++ b/packages/nestjs-timeout/src/timeout/timeout.interceptor.ts
@@ -6,7 +6,7 @@ import { catchError, timeout } from 'rxjs/operators';
  * An interceptor that throws an error if a request takes longer than the provided timeout.
  */
 // Adapted from https://stackoverflow.com/a/66852766/10808983
-export class TimeoutInterceptor<T> implements NestInterceptor {
+export class TimeoutInterceptor<T> implements NestInterceptor<T, T> {
   /**
    * Create a new {@link TimeoutInterceptor}.
    * @param timeoutMs - The number of milliseconds before a request times out


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

no effect for end-users, but ensures stricter adherence to the `NestInterceptor` interface.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written