### PR TITLE
[Merged by Bors] - fix: prototype type (VF-3038)

### DIFF
--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -41,6 +41,7 @@ export interface PrototypeSettings {
 }
 
 export interface Prototype<Command extends BaseCommand = BaseCommand, Locale extends string = string> {
+  type: string;
   data: PrototypeData<Locale>;
   model: PrototypeModel;
   context: PrototypeContext<Command>;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3038**

### Brief description. What is this change?
`type` needs to get included because only `version.prototype` is readable without auth, needs to get written.
