### PR TITLE
[Merged by Bors] - feat(nestjs-common): rename `HealthCheckError` to `HealthCheckErrorDto` (VF-000)

### DIFF
--- a/packages/nestjs-common/src/health/health-check-error.dto.ts
+++ b/packages/nestjs-common/src/health/health-check-error.dto.ts
@@ -8,7 +8,7 @@ type PlainError = Pick<Error, keyof Error>;
 /**
  * A health-check compatible plain object to represent an error that occurred.
  */
-export class HealthCheckError<T = unknown> {
+export class HealthCheckErrorDto<T = unknown> {
   readonly error: PlainError | null;
 
   readonly rawError: T;

--- a/packages/nestjs-common/src/index.ts
+++ b/packages/nestjs-common/src/index.ts
@@ -1,1 +1,7 @@
-export { HealthCheckError } from './health/health-check-error.dto';
+export {
+  /**
+   * @deprecated Renamed to {@link HealthCheckErrorDto}.
+   */
+  HealthCheckErrorDto as HealthCheckError,
+  HealthCheckErrorDto,
+} from './health/health-check-error.dto';

--- a/packages/nestjs-common/tests/health/health-check-error.dto.unit.ts
+++ b/packages/nestjs-common/tests/health/health-check-error.dto.unit.ts
@@ -1,10 +1,10 @@
-import { HealthCheckError } from '@nestjs-common/health/health-check-error.dto';
+import { HealthCheckErrorDto } from '@nestjs-common/health/health-check-error.dto';
 import { expect } from 'chai';
 
-describe('HealthCheckError', () => {
+describe('HealthCheckErrorDto', () => {
   it('works with Error instances', () => {
     const error = new Error('test');
-    const healthCheckError = new HealthCheckError(error);
+    const healthCheckError = new HealthCheckErrorDto(error);
 
     expect(healthCheckError.error).to.deep.equal({
       name: 'Error',
@@ -18,7 +18,7 @@ describe('HealthCheckError', () => {
     const error = {
       key: 'value',
     };
-    const healthCheckError = new HealthCheckError(error);
+    const healthCheckError = new HealthCheckErrorDto(error);
 
     expect(healthCheckError.error).to.eq(null);
     expect(healthCheckError.rawError).to.eq(error);


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

renames `HealthCheckError` to `HealthCheckErrorDto` to avoid a naming conflict with `HealthCheckError` from `@nestjs/terminus`

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written