### PR TITLE
[Merged by Bors] - feat: breaking platform type (VF-3162)

### DIFF
--- a/packages/voiceflow-types/src/constants/platformType.ts
+++ b/packages/voiceflow-types/src/constants/platformType.ts
@@ -1,7 +1,7 @@
 export enum PlatformType {
   ALEXA = 'alexa',
   GOOGLE = 'google',
-  VOICEFLOW = 'general',
+  VOICEFLOW = 'voiceflow',
   DIALOGFLOW_ES = 'df-es',
 
   /** @deprecated use VOICEFLOW instead */


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

`PlatformType.VOICEFLOW` is the exact same as `PlatformType.GENERAL`
this causes problems in the adapter: https://github.com/voiceflow/creator-app/blob/066720d00d3e5c9d8c7fdbfc94d774e970764b53/packages/realtime-sdk/src/constants/platform.ts#L48-L56

This new `voiceflow` type is only ever referenced in the FE (adapted) and never saved in the database, so it should be fine.