### PR TITLE
[Merged by Bors] - feat: allow function as default value for map get (VF-000)

### DIFF
--- a/packages/common/src/utils/map.ts
+++ b/packages/common/src/utils/map.ts
@@ -1,11 +1,16 @@
+const isDefaultValueAFunction = <V>(value: unknown): value is () => V => typeof value === 'function';
+
+export function getOrDefault<K, V>(map: Map<K, V>, key: K, defaultValue: V): V;
+export function getOrDefault<K, V>(map: Map<K, V>, key: K, getDefaultValue: () => V): V;
 /**
  * Retrieve the value at the given key inside the map.
  * If the key does not exist, insert the default value into the map and return that value.
  */
-export const getOrDefault = <K, V>(map: Map<K, V>, key: K, defaultValue: V): V => {
+export function getOrDefault<K, V>(map: Map<K, V>, key: K, defaultValue: V | (() => V)): V {
   if (!map.has(key)) {
-    map.set(key, defaultValue);
-    return defaultValue;
+    const value = isDefaultValueAFunction(defaultValue) ? defaultValue() : defaultValue;
+    map.set(key, value);
+    return value;
   }
   return map.get(key)!;
-};
+}

--- a/packages/common/src/utils/map.ts
+++ b/packages/common/src/utils/map.ts
@@ -1,4 +1,4 @@
-const isDefaultValueAFunction = <V>(value: unknown): value is () => V => typeof value === 'function';
+import { isFunction } from './functional';
 
 export function getOrDefault<K, V>(map: Map<K, V>, key: K, defaultValue: V): V;
 export function getOrDefault<K, V>(map: Map<K, V>, key: K, getDefaultValue: () => V): V;
@@ -8,7 +8,7 @@ export function getOrDefault<K, V>(map: Map<K, V>, key: K, getDefaultValue: () =
  */
 export function getOrDefault<K, V>(map: Map<K, V>, key: K, defaultValue: V | (() => V)): V {
   if (!map.has(key)) {
-    const value = isDefaultValueAFunction(defaultValue) ? defaultValue() : defaultValue;
+    const value = isFunction(defaultValue) ? defaultValue() : defaultValue;
     map.set(key, value);
     return value;
   }

--- a/packages/common/tests/utils/map.unit.ts
+++ b/packages/common/tests/utils/map.unit.ts
@@ -14,5 +14,11 @@ describe('Utils | map', () => {
       const value = getOrDefault(map, 'key', 'other');
       expect(value).to.equal('other');
     });
+
+    it('inserts and returns the result of the default value function if key does not exist in the map', () => {
+      const map = new Map<string, string>();
+      const value = getOrDefault(map, 'key', () => 'other');
+      expect(value).to.equal('other');
+    });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Allows the default value to be a function for a value. Useful for when you only want the default value to be evaluated if the key doesn't exist already.