### PR TITLE
[Merged by Bors] - feat(nestjs-metrics): create `@voiceflow/nestjs-metrics` package (VF-2949)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ dist
 
 build/
 sonar/
-nyc_coverage*
+nyc_*
 
 .npmrc
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["editorconfig.editorconfig", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "mikestead.dotenv"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,11 @@
 {
-  "files.autoSave": "onFocusChange",
-  "editor.formatOnPaste": true,
-  "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "editor.detectIndentation": false,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.tslint": true,
-    "source.fixAll.eslint": true
-  },
   "eslint.format.enable": true,
   "eslint.lintTask.enable": true,
   "eslint.packageManager": "yarn",
-  "css.validate": false,
-  "less.validate": false,
-  "scss.validate": false,
-  "javascript.validate.enable": false,
   "javascript.updateImportsOnFileMove.enabled": "always",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
@@ -31,5 +21,5 @@
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
-  "cSpell.words": ["typeguard"]
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/nestjs-metrics/.depcheckrc
+++ b/packages/nestjs-metrics/.depcheckrc
@@ -1,0 +1,23 @@
+{
+  "specials": [
+    "bin",
+    "eslint",
+    "lint-staged",
+    "istanbul",
+    "commitizen",
+    "husky",
+    "prettier",
+    "ttypescript"
+  ],
+  "ignores": [
+    "@nestjs-metrics/*",
+    "@commitlint/*",
+    "@types/*",
+    "@voiceflow/commitlint-config",
+    "@voiceflow/git-branch-check",
+    "fixpack",
+    "husky",
+    "lint-staged",
+    "eslint-import-resolver-typescript"
+  ]
+}

--- a/packages/nestjs-metrics/.eslintignore
+++ b/packages/nestjs-metrics/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+build
+nyc_*
+.nyc_*

--- a/packages/nestjs-metrics/.eslintrc.js
+++ b/packages/nestjs-metrics/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: {
+    'no-underscore-dangle': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    'class-methods-use-this': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: true,
+      },
+    ],
+  },
+};

--- a/packages/nestjs-metrics/.nycrc.json
+++ b/packages/nestjs-metrics/.nycrc.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "include": [
+    "src/**"
+  ],
+  "reporter": [
+    "html",
+    "text",
+    "text-summary",
+    "lcov"
+  ],
+  "report-dir": "nyc_coverage",
+  "extension": [
+    ".ts"
+  ]
+}

--- a/packages/nestjs-metrics/CHANGELOG.md
+++ b/packages/nestjs-metrics/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/nestjs-metrics/README.md
+++ b/packages/nestjs-metrics/README.md
@@ -1,0 +1,9 @@
+# NestJS Metrics
+
+Record NestJS application metrics with OpenTelemetry.
+
+## Installation
+
+```sh
+yarn add @voiceflow/nestjs-metrics
+```

--- a/packages/nestjs-metrics/config/tests/mocharc.yml
+++ b/packages/nestjs-metrics/config/tests/mocharc.yml
@@ -1,0 +1,18 @@
+require:
+  - source-map-support/register
+
+timeout: 4000
+exit: true
+recursive: true
+
+watchFiles:
+  - test/**/*
+  - src/**/*
+watchExtensions:
+  - js
+  - jsx
+  - ts
+  - tsx
+
+spec:
+  - tests/setup.ts

--- a/packages/nestjs-metrics/package.json
+++ b/packages/nestjs-metrics/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@voiceflow/nestjs-metrics",
+  "description": "Record NestJS application metrics with OpenTelemetry.",
+  "version": "1.0.0",
+  "author": "Voiceflow",
+  "bugs": {
+    "url": "https://github.com/voiceflow/libs/issues"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "1.0.4",
+    "@opentelemetry/api-metrics": "0.27.0",
+    "@opentelemetry/exporter-prometheus": "0.27.0",
+    "@opentelemetry/sdk-metrics-base": "0.27.0"
+  },
+  "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@nestjs/common": "^8.4.1",
+    "@types/chai": "4.3.0",
+    "@types/chai-as-promised": "^7.1.4",
+    "@types/mocha": "^8.2.2",
+    "@types/node": "16.11.12",
+    "@zerollup/ts-transform-paths": "^1.7.18",
+    "chai": "4.3.6",
+    "chai-as-promised": "^7.1.1",
+    "depcheck": "^1.4.1",
+    "lint-staged": "^11.0.0",
+    "mocha": "9.1.3",
+    "nyc": "^15.1.0",
+    "rimraf": "^3.0.2",
+    "ts-mocha": "^8.0.0",
+    "ts-node": "10.5.0",
+    "tsconfig-paths": "3.12.0",
+    "ttypescript": "1.5.13",
+    "typescript": "4.6.2"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "files": [
+    "build/"
+  ],
+  "homepage": "https://github.com/voiceflow/libs#readme",
+  "keywords": [
+    "metrics",
+    "nestjs",
+    "opentelemetry",
+    "prometheus",
+    "stats",
+    "telemetry",
+    "voiceflow"
+  ],
+  "license": "ISC",
+  "main": "build/index.js",
+  "peerDependencies": {
+    "@nestjs/common": "^8.4.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voiceflow/libs.git"
+  },
+  "scripts": {
+    "build": "ttsc --project ./tsconfig.build.json",
+    "clean": "rimraf build",
+    "commit": "cz",
+    "lint": "eslint \"**/*.{js,ts}\"",
+    "lint:fix": "yarn lint --fix",
+    "lint:quiet": "yarn lint --quiet",
+    "lint:report": "eslint-output --quiet \"**/*.{js,ts}\"",
+    "prebuild": "yarn clean",
+    "tdd": "yarn test --watch",
+    "test": "yarn test:run",
+    "test:dependencies": "depcheck",
+    "test:integration": "NODE_ENV=test nyc --report-dir nyc_coverage_integration ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.it.ts'",
+    "test:run": "NODE_ENV=test nyc ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.{unit,it}.ts'",
+    "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
+    "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
+  },
+  "types": "build/index.d.ts"
+}

--- a/packages/nestjs-metrics/sonar-project.properties
+++ b/packages/nestjs-metrics/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectName=libs-nestjs-metrics
+sonar.sources=src
+sonar.tests=tests
+sonar.eslint.reportPaths=sonar/report.json
+sonar.typescript.tsconfigPath=./tsconfig.json
+sonar.javascript.lcov.reportPaths=nyc_coverage_unit/lcov.info,nyc_coverage_integration/lcov.info

--- a/packages/nestjs-metrics/src/constants.ts
+++ b/packages/nestjs-metrics/src/constants.ts
@@ -1,0 +1,3 @@
+export const Providers = {
+  OPTIONS: Symbol('@voiceflow/nestjs-metrics options'),
+} as const;

--- a/packages/nestjs-metrics/src/constants.ts
+++ b/packages/nestjs-metrics/src/constants.ts
@@ -1,3 +1,3 @@
 export const Providers = {
-  OPTIONS: Symbol('@voiceflow/nestjs-metrics options'),
+  METRICS_OPTIONS: Symbol('@voiceflow/nestjs-metrics MetricsOptions'),
 } as const;

--- a/packages/nestjs-metrics/src/index.ts
+++ b/packages/nestjs-metrics/src/index.ts
@@ -1,0 +1,3 @@
+export { MetricsModule } from './metrics.module';
+export { MetricsService } from './metrics.service';
+export { HistogramStopwatch } from './stopwatch';

--- a/packages/nestjs-metrics/src/interfaces/metrics-options.interface.ts
+++ b/packages/nestjs-metrics/src/interfaces/metrics-options.interface.ts
@@ -1,0 +1,18 @@
+import { ModuleMetadata, Type } from '@nestjs/common';
+
+export interface MetricsOptions {
+  readonly serviceName: string;
+  readonly interval: number;
+  readonly port: number;
+}
+
+export interface MetricsOptionsFactory {
+  createMetricsOptions: () => PromiseLike<MetricsOptions> | MetricsOptions;
+}
+
+export interface MetricsModuleAsyncOptions extends Omit<ModuleMetadata, 'useExisting' | 'useClass' | 'useFactory' | 'inject'> {
+  useExisting?: Type<MetricsOptionsFactory>;
+  useClass?: Type<MetricsOptionsFactory>;
+  useFactory?: (...args: any[]) => PromiseLike<MetricsOptions> | MetricsOptions;
+  inject?: any[];
+}

--- a/packages/nestjs-metrics/src/interfaces/metrics-options.interface.ts
+++ b/packages/nestjs-metrics/src/interfaces/metrics-options.interface.ts
@@ -6,13 +6,8 @@ export interface MetricsOptions {
   readonly port: number;
 }
 
-export interface MetricsOptionsFactory {
-  createMetricsOptions: () => PromiseLike<MetricsOptions> | MetricsOptions;
-}
-
-export interface MetricsModuleAsyncOptions extends Omit<ModuleMetadata, 'useExisting' | 'useClass' | 'useFactory' | 'inject'> {
-  useExisting?: Type<MetricsOptionsFactory>;
-  useClass?: Type<MetricsOptionsFactory>;
+export interface MetricsModuleAsyncOptions extends Pick<ModuleMetadata, 'providers' | 'imports'> {
+  useClass?: Type<MetricsOptions>;
   useFactory?: (...args: any[]) => PromiseLike<MetricsOptions> | MetricsOptions;
   inject?: any[];
 }

--- a/packages/nestjs-metrics/src/metrics.module.ts
+++ b/packages/nestjs-metrics/src/metrics.module.ts
@@ -1,0 +1,71 @@
+import { DynamicModule, Module, Provider } from '@nestjs/common';
+
+import { Providers } from './constants';
+import { MetricsModuleAsyncOptions, MetricsOptions, MetricsOptionsFactory } from './interfaces/metrics-options.interface';
+import { MetricsService } from './metrics.service';
+
+@Module({})
+export class MetricsModule {
+  static register(options: MetricsOptions): DynamicModule {
+    return {
+      module: MetricsModule,
+      providers: [{ provide: Providers.OPTIONS, useValue: options }, MetricsService],
+      exports: [MetricsService, Providers.OPTIONS],
+    };
+  }
+
+  static registerAsync(options: MetricsModuleAsyncOptions): DynamicModule {
+    return {
+      module: MetricsModule,
+      imports: options.imports,
+      providers: [...this.createAsyncProviders(options), MetricsService],
+      exports: [MetricsService, Providers.OPTIONS],
+    };
+  }
+
+  private static createAsyncProviders(options: MetricsModuleAsyncOptions): Provider[] {
+    if (options.useExisting || options.useFactory) {
+      return [this.createAsyncOptionsProvider(options)];
+    }
+
+    if (options.useClass) {
+      return [
+        this.createAsyncOptionsProvider(options),
+        {
+          provide: options.useClass,
+          useClass: options.useClass,
+        },
+      ];
+    }
+
+    throw new RangeError('Expected a useExisting, useFactory, or useClass value to be present in the options');
+  }
+
+  private static createAsyncOptionsProvider(options: MetricsModuleAsyncOptions): Provider {
+    if (options.useFactory) {
+      return {
+        provide: Providers.OPTIONS,
+        useFactory: options.useFactory,
+        inject: options.inject || [],
+      };
+    }
+
+    if (options.useExisting) {
+      return {
+        provide: Providers.OPTIONS,
+        useFactory: async (optionsFactory: MetricsOptionsFactory) => optionsFactory.createMetricsOptions(),
+        inject: [options.useExisting],
+      };
+    }
+
+    if (options.useClass) {
+      return {
+        provide: Providers.OPTIONS,
+        useFactory: async (optionsFactory: MetricsOptionsFactory) => optionsFactory.createMetricsOptions(),
+        inject: [options.useClass],
+      };
+    }
+
+    throw new RangeError('Expected a useExisting, useFactory, or useClass value to be present in the options');
+  }
+}

--- a/packages/nestjs-metrics/src/metrics.module.ts
+++ b/packages/nestjs-metrics/src/metrics.module.ts
@@ -10,8 +10,8 @@ export class MetricsModule {
     return {
       global: true,
       module: MetricsModule,
-      providers: [{ provide: Providers.OPTIONS, useValue: options }, MetricsService],
-      exports: [MetricsService, Providers.OPTIONS],
+      providers: [{ provide: Providers.METRICS_OPTIONS, useValue: options }, MetricsService],
+      exports: [MetricsService, Providers.METRICS_OPTIONS],
     };
   }
 
@@ -23,14 +23,14 @@ export class MetricsModule {
         imports: options.imports,
         providers: [
           {
-            provide: Providers.OPTIONS,
+            provide: Providers.METRICS_OPTIONS,
             useFactory: options.useFactory,
             inject: options.inject ?? [],
           },
           MetricsService,
           ...(options.providers ?? []),
         ],
-        exports: [MetricsService, Providers.OPTIONS],
+        exports: [MetricsService, Providers.METRICS_OPTIONS],
       };
     }
 
@@ -41,14 +41,14 @@ export class MetricsModule {
         imports: options.imports,
         providers: [
           {
-            provide: Providers.OPTIONS,
+            provide: Providers.METRICS_OPTIONS,
             useClass: options.useClass,
             inject: options.inject ?? [],
           },
           MetricsService,
           ...(options.providers ?? []),
         ],
-        exports: [MetricsService, Providers.OPTIONS],
+        exports: [MetricsService, Providers.METRICS_OPTIONS],
       };
     }
 

--- a/packages/nestjs-metrics/src/metrics.module.ts
+++ b/packages/nestjs-metrics/src/metrics.module.ts
@@ -1,68 +1,54 @@
-import { DynamicModule, Module, Provider } from '@nestjs/common';
+import { DynamicModule, Module } from '@nestjs/common';
 
 import { Providers } from './constants';
-import { MetricsModuleAsyncOptions, MetricsOptions, MetricsOptionsFactory } from './interfaces/metrics-options.interface';
+import { MetricsModuleAsyncOptions, MetricsOptions } from './interfaces/metrics-options.interface';
 import { MetricsService } from './metrics.service';
 
 @Module({})
 export class MetricsModule {
-  static register(options: MetricsOptions): DynamicModule {
+  static forRoot(options: MetricsOptions): DynamicModule {
     return {
+      global: true,
       module: MetricsModule,
       providers: [{ provide: Providers.OPTIONS, useValue: options }, MetricsService],
       exports: [MetricsService, Providers.OPTIONS],
     };
   }
 
-  static registerAsync(options: MetricsModuleAsyncOptions): DynamicModule {
-    return {
-      module: MetricsModule,
-      imports: options.imports,
-      providers: [...this.createAsyncProviders(options), MetricsService],
-      exports: [MetricsService, Providers.OPTIONS],
-    };
-  }
-
-  private static createAsyncProviders(options: MetricsModuleAsyncOptions): Provider[] {
-    if (options.useExisting || options.useFactory) {
-      return [this.createAsyncOptionsProvider(options)];
-    }
-
-    if (options.useClass) {
-      return [
-        this.createAsyncOptionsProvider(options),
-        {
-          provide: options.useClass,
-          useClass: options.useClass,
-        },
-      ];
-    }
-
-    throw new RangeError('Expected a useExisting, useFactory, or useClass value to be present in the options');
-  }
-
-  private static createAsyncOptionsProvider(options: MetricsModuleAsyncOptions): Provider {
+  static forRootAsync(options: MetricsModuleAsyncOptions): DynamicModule {
     if (options.useFactory) {
       return {
-        provide: Providers.OPTIONS,
-        useFactory: options.useFactory,
-        inject: options.inject || [],
-      };
-    }
-
-    if (options.useExisting) {
-      return {
-        provide: Providers.OPTIONS,
-        useFactory: async (optionsFactory: MetricsOptionsFactory) => optionsFactory.createMetricsOptions(),
-        inject: [options.useExisting],
+        global: true,
+        module: MetricsModule,
+        imports: options.imports,
+        providers: [
+          {
+            provide: Providers.OPTIONS,
+            useFactory: options.useFactory,
+            inject: options.inject ?? [],
+          },
+          MetricsService,
+          ...(options.providers ?? []),
+        ],
+        exports: [MetricsService, Providers.OPTIONS],
       };
     }
 
     if (options.useClass) {
       return {
-        provide: Providers.OPTIONS,
-        useFactory: async (optionsFactory: MetricsOptionsFactory) => optionsFactory.createMetricsOptions(),
-        inject: [options.useClass],
+        global: true,
+        module: MetricsModule,
+        imports: options.imports,
+        providers: [
+          {
+            provide: Providers.OPTIONS,
+            useClass: options.useClass,
+            inject: options.inject ?? [],
+          },
+          MetricsService,
+          ...(options.providers ?? []),
+        ],
+        exports: [MetricsService, Providers.OPTIONS],
       };
     }
 

--- a/packages/nestjs-metrics/src/metrics.service.ts
+++ b/packages/nestjs-metrics/src/metrics.service.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { Counter, Histogram, MetricOptions, metrics, UpDownCounter } from '@opentelemetry/api-metrics';
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import { Meter, MeterProvider, MetricExporter } from '@opentelemetry/sdk-metrics-base';
+
+import { Providers } from './constants';
+import { MetricsOptions } from './interfaces/metrics-options.interface';
+
+@Injectable()
+export class MetricsService implements OnApplicationShutdown {
+  private readonly exporter: MetricExporter;
+
+  private readonly meter: Meter;
+
+  private readonly counters: Map<string, Counter> = new Map();
+
+  private readonly histograms: Map<string, Histogram> = new Map();
+
+  private readonly upDownCounters: Map<string, UpDownCounter> = new Map();
+
+  constructor(@Inject(Providers.OPTIONS) config: MetricsOptions) {
+    this.exporter = new PrometheusExporter({ port: config.port });
+
+    const meterProvider = new MeterProvider({
+      exporter: this.exporter,
+      interval: config.interval,
+    });
+
+    this.meter = meterProvider.getMeter(config.serviceName);
+    metrics.setGlobalMeterProvider(meterProvider);
+  }
+
+  async onApplicationShutdown(): Promise<void> {
+    await this.exporter.shutdown();
+    await this.meter.shutdown();
+  }
+
+  getOrCreateCounter(name: string, options?: MetricOptions): Counter {
+    let counter = this.counters.get(name);
+
+    if (!counter) {
+      counter = this.meter.createCounter(name, options);
+      this.counters.set(name, counter);
+    }
+
+    return counter;
+  }
+
+  getOrCreateHistogram(name: string, options?: MetricOptions): Histogram {
+    let histogram = this.histograms.get(name);
+
+    if (!histogram) {
+      histogram = this.meter.createHistogram(name, options);
+      this.histograms.set(name, histogram);
+    }
+
+    return histogram;
+  }
+
+  getOrCreateUpDownCounter(name: string, options?: MetricOptions): UpDownCounter {
+    let upDownCounter = this.upDownCounters.get(name);
+
+    if (!upDownCounter) {
+      upDownCounter = this.meter.createUpDownCounter(name, options);
+      this.upDownCounters.set(name, upDownCounter);
+    }
+
+    return upDownCounter;
+  }
+}

--- a/packages/nestjs-metrics/src/metrics.service.ts
+++ b/packages/nestjs-metrics/src/metrics.service.ts
@@ -18,7 +18,7 @@ export class MetricsService implements OnApplicationShutdown {
 
   private readonly upDownCounters: Map<string, UpDownCounter> = new Map();
 
-  constructor(@Inject(Providers.OPTIONS) config: MetricsOptions) {
+  constructor(@Inject(Providers.METRICS_OPTIONS) config: MetricsOptions) {
     this.exporter = new PrometheusExporter({ port: config.port });
 
     const meterProvider = new MeterProvider({

--- a/packages/nestjs-metrics/src/stopwatch.ts
+++ b/packages/nestjs-metrics/src/stopwatch.ts
@@ -1,0 +1,33 @@
+import { Attributes, Histogram } from '@opentelemetry/api-metrics';
+import { performance } from 'perf_hooks';
+
+/**
+ * A class to help record a duration (in milliseconds) in a histogram.
+ * Generally used for measuring performance.
+ */
+export class HistogramStopwatch {
+  /** Get a monotonic timestamp in milliseconds. */
+  private static getMonotonicTime(): number {
+    return performance.now();
+  }
+
+  private readonly startTime = HistogramStopwatch.getMonotonicTime();
+
+  private constructor(private readonly histogram: Histogram) {}
+
+  /** Create a new stopwatch and start recording time. */
+  static start(histogram: Histogram): HistogramStopwatch {
+    return new HistogramStopwatch(histogram);
+  }
+
+  /**
+   * Records a duration in milliseconds to this {@link HistogramStopwatch.histogram stopwatch's histogram}.
+   * If attributes were passed they will also be recorded.
+   */
+  finish(attributes?: Attributes | undefined): void {
+    const endTime = HistogramStopwatch.getMonotonicTime();
+    const durationMilliseconds = endTime - this.startTime;
+
+    this.histogram.record(durationMilliseconds, attributes);
+  }
+}

--- a/packages/nestjs-metrics/tests/setup.ts
+++ b/packages/nestjs-metrics/tests/setup.ts
@@ -1,0 +1,4 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);

--- a/packages/nestjs-metrics/tsconfig.build.json
+++ b/packages/nestjs-metrics/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "build",
+    "plugins": [
+      {
+        "transform": "@zerollup/ts-transform-paths"
+      }
+    ],
+    "traceResolution": false,
+    "skipLibCheck": true
+  },
+  "include": ["src", "typings"]
+}

--- a/packages/nestjs-metrics/tsconfig.json
+++ b/packages/nestjs-metrics/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "extends": "@voiceflow/tsconfig",
+  "compilerOptions": {
+    // General
+    "target": "es2021",
+    "module": "commonjs",
+    "lib": ["es2021"],
+    "experimentalDecorators": true,
+    "baseUrl": "./",
+    "paths": {
+      "@nestjs-metrics/*": ["src/*"]
+    },
+
+    // Strictness
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Modules
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+
+    // Emit
+    "outDir": "./build",
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "sourceMap": true
+  },
+  "include": ["src", "tests", "typings"],
+  "exclude": ["**/node_modules", "**/.*/"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,21 +1970,6 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
-
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -7515,28 +7500,7 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,6 +1146,16 @@
     tslib "2.3.0"
     uuid "8.3.2"
 
+"@nestjs/common@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-8.4.1.tgz#2a0d166d29beb5bf740dfdddc62c7bd04c39c53f"
+  integrity sha512-g6beLHvJ2cCIdlW8Uui8rQh3+oxLOBLzDIk3yWH4ocp2HEgOJwF0iUv/pk33tFuwbXESIGMK8K165cpZUjNoxA==
+  dependencies:
+    axios "0.26.1"
+    iterare "1.2.1"
+    tslib "2.3.1"
+    uuid "8.3.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1343,10 +1353,20 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.26.0.tgz#6f98a5467140ab97f23f598b26e0e18ad8ec59f3"
   integrity sha512-idDSUTx+LRwJiHhVHhdh45SWow5u9lKNDROKu5AMzsIVPI29utH5FfT9vor8qMM6blxWWvlT22HUNdNMWqUQfQ==
 
+"@opentelemetry/api-metrics@0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.27.0.tgz#d8eca344ed1155f3ea8a8133ade827b4bb90efbf"
+  integrity sha512-tB79288bwjkdhPNpw4UdOEy3bacVwtol6Que7cAu8KEJ9ULjRfSiwpYEwJY/oER3xZ7zNFz0uiJ7N1jSiotpVA==
+
 "@opentelemetry/api@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.3.tgz#13a12ae9e05c2a782f7b5e84c3cbfda4225eaf80"
   integrity sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==
+
+"@opentelemetry/api@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.4.tgz#a167e46c10d05a07ab299fc518793b0cff8f6924"
+  integrity sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==
 
 "@opentelemetry/core@1.0.0":
   version "1.0.0"
@@ -1355,6 +1375,13 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "1.0.0"
     semver "^7.3.5"
+
+"@opentelemetry/core@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.0.1.tgz#5e08cef21946fdea7952f544e8f667f6d2a0ded8"
+  integrity sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.0.1"
 
 "@opentelemetry/exporter-prometheus@0.26.0":
   version "0.26.0"
@@ -1365,6 +1392,15 @@
     "@opentelemetry/core" "1.0.0"
     "@opentelemetry/sdk-metrics-base" "0.26.0"
 
+"@opentelemetry/exporter-prometheus@0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.27.0.tgz#12d00aedb75ebcfd24d2b151504b2a7c4d51f0f4"
+  integrity sha512-fbdV+iQAv/WNhiv57C6+9Lwyhc6yJuDy3eyYSyPSVPgCyclGS3fvyTaWNwPbrkE53W8zZHPm+88rAaeQgEjo0w==
+  dependencies:
+    "@opentelemetry/api-metrics" "0.27.0"
+    "@opentelemetry/core" "1.0.1"
+    "@opentelemetry/sdk-metrics-base" "0.27.0"
+
 "@opentelemetry/resources@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.0.0.tgz#6fb83d39d8305ea75cb3e120583d125670b3d6ac"
@@ -1372,6 +1408,14 @@
   dependencies:
     "@opentelemetry/core" "1.0.0"
     "@opentelemetry/semantic-conventions" "1.0.0"
+
+"@opentelemetry/resources@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.0.1.tgz#2d190e2e6e64327b436447a8dd799afc673b6e07"
+  integrity sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==
+  dependencies:
+    "@opentelemetry/core" "1.0.1"
+    "@opentelemetry/semantic-conventions" "1.0.1"
 
 "@opentelemetry/sdk-metrics-base@0.26.0":
   version "0.26.0"
@@ -1383,10 +1427,25 @@
     "@opentelemetry/resources" "1.0.0"
     lodash.merge "^4.6.2"
 
+"@opentelemetry/sdk-metrics-base@0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.27.0.tgz#cbd9189dd427d445c39aa3981fcc769891db1918"
+  integrity sha512-HpiWI4sVNsjp3FGyUlc24KvUY2Whl4PQVwcbA/gWv2kHaLQrDJrWC+3rjUR+87Mrd0nsiqJ85xhGFU6IK8h7gg==
+  dependencies:
+    "@opentelemetry/api-metrics" "0.27.0"
+    "@opentelemetry/core" "1.0.1"
+    "@opentelemetry/resources" "1.0.1"
+    lodash.merge "^4.6.2"
+
 "@opentelemetry/semantic-conventions@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.0.tgz#2b3aa897adabf8324585a5b9766268f0ceeb9fba"
   integrity sha512-XCZ6ZSmc8FOspxKUU+Ow9UtJeSSRcS5rFBYGpjzix02U2v+X9ofjOjgNRnpvxlSvkccYIhdTuwcvNskmZ46SeA==
+
+"@opentelemetry/semantic-conventions@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz#9349c3860a53468fa2108b5df09aa843f22dbf94"
+  integrity sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
@@ -1911,6 +1970,21 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -2136,6 +2210,13 @@ axios@0.24.0:
   integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
     follow-redirects "^1.14.4"
+
+axios@0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -3869,7 +3950,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@^1.10.0:
+follow-redirects@^1.10.0, follow-redirects@^1.14.8:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -7434,7 +7515,28 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7723,15 +7825,15 @@ tslib@2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
+tslib@2.3.1, tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.1.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
**Fixes or implements VF-2949**

### Brief description. What is this change?

adds a `@voiceflow/nestjs-metrics` package for reusing the metrics module from canvas-export

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written