### PR TITLE
[Merged by Bors] - feat(common): add `toArray()` function (VF-000)

### DIFF
--- a/packages/common/src/utils/array.ts
+++ b/packages/common/src/utils/array.ts
@@ -149,3 +149,5 @@ export const filterAndGetLastRemovedValue = <T>(list: T[], filter: (item: T) => 
 };
 
 export const inferUnion = <T extends ArrayLike<unknown>>(array: T): ArrayUnionToIntersection<T> => array as unknown as ArrayUnionToIntersection<T>;
+
+export const toArray = <T>(valueOrArray: T | T[]): T[] => (Array.isArray(valueOrArray) ? valueOrArray : [valueOrArray]);

--- a/packages/common/tests/utils/array.unit.ts
+++ b/packages/common/tests/utils/array.unit.ts
@@ -8,6 +8,7 @@ import {
   isNullish,
   replace,
   tail,
+  toArray,
   toggleMembership,
   unique,
   without,
@@ -130,6 +131,20 @@ describe('Utils | array', () => {
       expect(isNotNullish(null)).to.eql(false);
       expect(isNotNullish(undefined)).to.eql(false);
       expect(isNotNullish(0)).to.eql(true);
+    });
+  });
+
+  describe('toArray()', () => {
+    it('works with arrays', () => {
+      const value = [1];
+
+      expect(toArray(value)).to.eql([1]);
+    });
+
+    it('works with non-arrays', () => {
+      const value = 1;
+
+      expect(toArray(value)).to.eql([1]);
     });
   });
 });


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

for working with values that are `T | T[]` but you want a `T[]`

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
