### PR TITLE
[Merged by Bors] - fix: moving slot annotation regex (VF-3190)

### DIFF
--- a/packages/common/src/constants/regexp.ts
+++ b/packages/common/src/constants/regexp.ts
@@ -2,6 +2,8 @@ export const SPACE_REGEXP = / /g;
 
 export const SLOT_REGEXP = /{{\[([^ .[\]{}]*?)]\.([^ .[\]{}]*?)}}/g;
 
+export const SLOT_ANNOTATION_SIMPLE_REGEX = /{([^ .[\]{}]+?)}/g;
+
 export const IS_VARIABLE_REGEXP = /^{.*}$/;
 
 export const READABLE_VARIABLE_REGEXP = /{(\w{1,64})}/g;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?
moved a constant to libs

