### PR TITLE
feat: add support for new port schema (VF-3082)

### DIFF
--- a/packages/alexa-types/src/node/cancelPayment.ts
+++ b/packages/alexa-types/src/node/cancelPayment.ts
@@ -6,9 +6,9 @@ export interface StepData {
   productID: string;
 }
 
-export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+export interface StepPorts extends BaseNode.Utils.SuccessFailStepPorts<[]> {}
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
+export interface Step extends BaseNode.Utils.BaseStep<StepData, StepPorts> {
   type: NodeType.CANCEL_PAYMENT;
 }
 

--- a/packages/alexa-types/src/node/cancelPayment.ts
+++ b/packages/alexa-types/src/node/cancelPayment.ts
@@ -6,7 +6,9 @@ export interface StepData {
   productID: string;
 }
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData> {
+export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+
+export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
   type: NodeType.CANCEL_PAYMENT;
 }
 

--- a/packages/alexa-types/src/node/payment.ts
+++ b/packages/alexa-types/src/node/payment.ts
@@ -6,7 +6,9 @@ export interface StepData {
   productID: Nullable<string>;
 }
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData> {
+export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+
+export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
   type: NodeType.PAYMENT;
 }
 

--- a/packages/alexa-types/src/node/payment.ts
+++ b/packages/alexa-types/src/node/payment.ts
@@ -6,9 +6,9 @@ export interface StepData {
   productID: Nullable<string>;
 }
 
-export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+export interface StepPorts extends BaseNode.Utils.SuccessFailStepPorts<[]> {}
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
+export interface Step extends BaseNode.Utils.BaseStep<StepData, StepPorts> {
   type: NodeType.PAYMENT;
 }
 

--- a/packages/alexa-types/src/node/reminder.ts
+++ b/packages/alexa-types/src/node/reminder.ts
@@ -36,7 +36,9 @@ export interface StepData {
   reminder: Reminder;
 }
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData> {
+export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+
+export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
   type: NodeType.REMINDER;
 }
 

--- a/packages/alexa-types/src/node/reminder.ts
+++ b/packages/alexa-types/src/node/reminder.ts
@@ -36,9 +36,9 @@ export interface StepData {
   reminder: Reminder;
 }
 
-export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+export interface StepPorts extends BaseNode.Utils.SuccessFailStepPorts<[]> {}
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
+export interface Step extends BaseNode.Utils.BaseStep<StepData, StepPorts> {
   type: NodeType.REMINDER;
 }
 

--- a/packages/alexa-types/src/node/stream.ts
+++ b/packages/alexa-types/src/node/stream.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseModels, BaseNode } from '@voiceflow/base-types';
 
 export interface StepData {
   loop: boolean;
@@ -13,9 +13,8 @@ export interface StepData {
 export interface StepPorts
   extends BaseNode.Utils.BaseStepPorts<
     {
-      [BaseNode.PortType.NEXT]: BaseNode.Utils.BasePort;
-      [BaseNode.PortType.FAIL]: BaseNode.Utils.BasePort;
-      [BaseNode.PortType.PAUSE]?: BaseNode.Utils.BasePort;
+      [BaseModels.PortType.PREVIOUS]: BaseNode.Utils.BasePort;
+      [BaseModels.PortType.PAUSE]?: BaseNode.Utils.BasePort;
     },
     []
   > {}

--- a/packages/alexa-types/src/node/stream.ts
+++ b/packages/alexa-types/src/node/stream.ts
@@ -11,13 +11,10 @@ export interface StepData {
 }
 
 export interface StepPorts
-  extends BaseNode.Utils.BaseStepPorts<
-    {
-      [BaseModels.PortType.PREVIOUS]: BaseNode.Utils.BasePort;
-      [BaseModels.PortType.PAUSE]?: BaseNode.Utils.BasePort;
-    },
-    []
-  > {}
+  extends BaseNode.Stream.StepPorts<{
+    [BaseModels.PortType.PREVIOUS]: BaseNode.Utils.BasePort;
+    [BaseModels.PortType.PAUSE]?: BaseNode.Utils.BasePort;
+  }> {}
 
 export interface Step extends BaseNode.Stream.Step<StepData, StepPorts> {}
 

--- a/packages/alexa-types/src/node/stream.ts
+++ b/packages/alexa-types/src/node/stream.ts
@@ -10,7 +10,17 @@ export interface StepData {
   backgroundImage?: string;
 }
 
-export interface Step extends BaseNode.Stream.Step<StepData> {}
+export interface StepPorts
+  extends BaseNode.Utils.BaseStepPorts<
+    {
+      [BaseNode.PortType.NEXT]: BaseNode.Utils.BasePort;
+      [BaseNode.PortType.FAIL]: BaseNode.Utils.BasePort;
+      [BaseNode.PortType.PAUSE]?: BaseNode.Utils.BasePort;
+    },
+    []
+  > {}
+
+export interface Step extends BaseNode.Stream.Step<StepData, StepPorts> {}
 
 export interface Node extends Pick<BaseNode.Stream.Node, keyof BaseNode.Utils.BaseNode> {
   loop: boolean;

--- a/packages/alexa-types/src/node/stream.ts
+++ b/packages/alexa-types/src/node/stream.ts
@@ -10,11 +10,12 @@ export interface StepData {
   backgroundImage?: string;
 }
 
-export interface StepPorts
-  extends BaseNode.Stream.StepPorts<{
-    [BaseModels.PortType.PREVIOUS]: BaseNode.Utils.BasePort;
-    [BaseModels.PortType.PAUSE]?: BaseNode.Utils.BasePort;
-  }> {}
+export interface StepBuiltInPorts extends BaseNode.Stream.StepBaseBuiltInPorts {
+  [BaseModels.PortType.PAUSE]?: BaseNode.Utils.BasePort;
+  [BaseModels.PortType.PREVIOUS]: BaseNode.Utils.BasePort;
+}
+
+export interface StepPorts extends BaseNode.Stream.StepPorts<StepBuiltInPorts> {}
 
 export interface Step extends BaseNode.Stream.Step<StepData, StepPorts> {}
 

--- a/packages/alexa-types/src/node/userInfo.ts
+++ b/packages/alexa-types/src/node/userInfo.ts
@@ -18,7 +18,9 @@ export interface Permission {
   selected: Nullable<{ value: string }>;
 }
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData> {
+export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+
+export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
   type: NodeType.USER_INFO;
 }
 

--- a/packages/alexa-types/src/node/userInfo.ts
+++ b/packages/alexa-types/src/node/userInfo.ts
@@ -18,9 +18,9 @@ export interface Permission {
   selected: Nullable<{ value: string }>;
 }
 
-export type StepPorts = BaseNode.Utils.SuccessFailStepPorts;
+export interface StepPorts extends BaseNode.Utils.SuccessFailStepPorts<[]> {}
 
-export interface Step extends BaseNode.Utils.BaseStep<StepData, BaseNode.Utils.BasePortList, StepPorts> {
+export interface Step extends BaseNode.Utils.BaseStep<StepData, StepPorts> {
   type: NodeType.USER_INFO;
 }
 

--- a/packages/base-types/src/models/base/index.ts
+++ b/packages/base-types/src/models/base/index.ts
@@ -3,5 +3,6 @@ export * from './common';
 export * from './intent';
 export * from './node';
 export * from './note';
+export * from './port';
 export * from './prototype';
 export * from './slot';

--- a/packages/base-types/src/models/base/node.ts
+++ b/packages/base-types/src/models/base/node.ts
@@ -1,4 +1,6 @@
-import { AnyRecord, Nullable } from '@base-types/types';
+import { AnyRecord } from '@base-types/types';
+
+import { BasePortList, NextStepPorts } from './port';
 
 /**
  * @deprecated use BaseNode instead
@@ -32,25 +34,14 @@ export interface BaseBlock<D extends AnyRecord = AnyRecord> extends BaseDiagramN
   coords: Point;
 }
 
-export enum PortType {
-  FAIL = 'fail',
-  NEXT = 'next',
-  PAUSE = 'pause',
-  NO_REPLY = 'no-reply',
-  NO_MATCH = 'else',
-  PREVIOUS = 'previous',
-}
+export type StepOnlyData<P, P2> =
+  | {
+      ports: P;
+      portsV2: never;
+    }
+  | {
+      ports: never;
+      portsV2: P2;
+    };
 
-export interface BasePort<PD extends AnyRecord = AnyRecord> {
-  id: string;
-  type: string | PortType;
-  data?: PD;
-  target: Nullable<string>;
-}
-
-// [BasePort, ...BasePort[]] means one or more ports
-export interface StepOnlyData<P = [BasePort, ...BasePort[]]> {
-  ports: P;
-}
-
-export interface BaseStep<D extends AnyRecord = AnyRecord, P = [BasePort, ...BasePort[]]> extends BaseDiagramNode<D & StepOnlyData<P>> {}
+export interface BaseStep<D extends AnyRecord = AnyRecord, P = BasePortList, P2 = NextStepPorts> extends BaseDiagramNode<D & StepOnlyData<P, P2>> {}

--- a/packages/base-types/src/models/base/node.ts
+++ b/packages/base-types/src/models/base/node.ts
@@ -34,14 +34,7 @@ export interface BaseBlock<D extends AnyRecord = AnyRecord> extends BaseDiagramN
   coords: Point;
 }
 
-export type StepOnlyData<P, P2> =
-  | {
-      ports: P;
-      portsV2?: never;
-    }
-  | {
-      ports?: never;
-      portsV2: P2;
-    };
+export type StepOnlyData<Ports, PortsOld> = { ports?: never; portsV2: Ports } | { ports: PortsOld; portsV2?: never };
 
-export interface BaseStep<D extends AnyRecord = AnyRecord, P = BasePortList, P2 = NextStepPorts> extends BaseDiagramNode<D & StepOnlyData<P, P2>> {}
+export interface BaseStep<Data extends AnyRecord = AnyRecord, Ports = NextStepPorts, PortsOld = BasePortList>
+  extends BaseDiagramNode<Data & StepOnlyData<Ports, PortsOld>> {}

--- a/packages/base-types/src/models/base/node.ts
+++ b/packages/base-types/src/models/base/node.ts
@@ -37,10 +37,10 @@ export interface BaseBlock<D extends AnyRecord = AnyRecord> extends BaseDiagramN
 export type StepOnlyData<P, P2> =
   | {
       ports: P;
-      portsV2: never;
+      portsV2?: never;
     }
   | {
-      ports: never;
+      ports?: never;
       portsV2: P2;
     };
 

--- a/packages/base-types/src/models/base/port.ts
+++ b/packages/base-types/src/models/base/port.ts
@@ -1,0 +1,24 @@
+import { PortType } from '@base-types/node/constants';
+import { AnyRecord, EmptyRecord, Nullable } from '@base-types/types';
+
+export interface BasePort<PD extends AnyRecord = AnyRecord> {
+  id: string;
+  type: string | PortType;
+  data?: PD;
+  target: Nullable<string>;
+}
+
+export interface BaseStepPorts<BP extends Record<string, BasePort> = Record<string, BasePort>, DP extends BasePort[] = BasePort[]> {
+  builtIn: BP;
+  dynamic: DP;
+}
+
+export interface EmptyStepPorts extends BaseStepPorts<EmptyRecord, []> {}
+
+export interface NextStepPorts<DP extends BasePort[] = []> extends BaseStepPorts<{ [PortType.NEXT]: BasePort }, DP> {}
+
+export interface SuccessFailStepPorts<DP extends BasePort[] = []>
+  extends BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.FAIL]: BasePort }, DP> {}
+
+// [BasePort, ...BasePort[]] means one or more ports
+export type BasePortList = [BasePort, ...BasePort[]];

--- a/packages/base-types/src/models/base/port.ts
+++ b/packages/base-types/src/models/base/port.ts
@@ -1,5 +1,13 @@
-import { PortType } from '@base-types/node/constants';
 import { AnyRecord, EmptyRecord, Nullable } from '@base-types/types';
+
+export enum PortType {
+  FAIL = 'fail',
+  NEXT = 'next',
+  PAUSE = 'pause',
+  NO_REPLY = 'no-reply',
+  NO_MATCH = 'else',
+  PREVIOUS = 'previous',
+}
 
 export interface BasePort<PD extends AnyRecord = AnyRecord> {
   id: string;

--- a/packages/base-types/src/models/base/port.ts
+++ b/packages/base-types/src/models/base/port.ts
@@ -1,4 +1,4 @@
-import { AnyRecord, EmptyRecord, Nullable } from '@base-types/types';
+import { EmptyRecord, Nullable } from '@base-types/types';
 
 export enum PortType {
   FAIL = 'fail',
@@ -9,24 +9,48 @@ export enum PortType {
   PREVIOUS = 'previous',
 }
 
-export interface BasePort<PD extends AnyRecord = AnyRecord> {
+export interface BasePort {
   id: string;
   type: string | PortType;
-  data?: PD;
   target: Nullable<string>;
 }
 
-export interface BaseStepPorts<BP extends Record<string, BasePort> = Record<string, BasePort>, DP extends BasePort[] = BasePort[]> {
-  builtIn: BP;
-  dynamic: DP;
+export interface BaseStepPorts<Builtin extends Partial<Record<PortType, BasePort>>, Dynamic extends BasePort[] = BasePort[]> {
+  builtIn: Builtin;
+  dynamic: Dynamic;
 }
+
+export interface BuiltInNextPort {
+  [PortType.NEXT]: BasePort;
+}
+
+export interface BuiltInFailPort {
+  [PortType.FAIL]: BasePort;
+}
+
+export interface BuiltInNoMatchPort {
+  [PortType.NO_MATCH]?: BasePort;
+}
+
+export interface BuiltInNoReplyPort {
+  [PortType.NO_REPLY]?: BasePort;
+}
+
+export interface BuiltInNextFailPorts extends BuiltInNextPort, BuiltInFailPort {}
+
+export interface BuiltInNoMatchNoReplyPorts extends BuiltInNoMatchPort, BuiltInNoReplyPort {}
 
 export interface EmptyStepPorts extends BaseStepPorts<EmptyRecord, []> {}
 
-export interface NextStepPorts<DP extends BasePort[] = []> extends BaseStepPorts<{ [PortType.NEXT]: BasePort }, DP> {}
+export interface NextStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<BuiltInNextPort, Dynamic> {}
 
-export interface SuccessFailStepPorts<DP extends BasePort[] = []>
-  extends BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.FAIL]: BasePort }, DP> {}
+export interface SuccessFailStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<BuiltInNextFailPorts, Dynamic> {}
 
-// [BasePort, ...BasePort[]] means one or more ports
-export type BasePortList = [BasePort, ...BasePort[]];
+export interface DynamicOnlyStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<EmptyRecord, Dynamic> {}
+
+export interface NoMatchNoReplyStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<BuiltInNoMatchNoReplyPorts, Dynamic> {}
+
+/**
+ * @deprecated
+ */
+export type BasePortList<Port extends BasePort = BasePort> = [Port, ...Port[]];

--- a/packages/base-types/src/node/_v1.ts
+++ b/packages/base-types/src/node/_v1.ts
@@ -1,6 +1,6 @@
 import { Nullable } from '@base-types/types';
 
-import { BaseEvent, BaseNode, BasePort, BaseStep, NodeID } from './utils';
+import { BaseEvent, BaseNode, BasePort, BaseStep, BaseStepPorts, NodeID } from './utils';
 
 export const _V1_STOP_TYPES = 'stopTypes';
 
@@ -24,6 +24,12 @@ export interface Node<Event = BaseEvent> extends BaseNode {
   payload: unknown;
   defaultPath?: number; // index starting from 0
 }
-export interface Step<Payload = unknown, Event = BaseEvent> extends BaseStep<StepData<Payload>, BasePort<{ event?: Event }>[]> {
+
+export interface Step<Payload = unknown, Event = BaseEvent>
+  extends BaseStep<
+    StepData<Payload>,
+    BasePort<{ event?: Event }>[],
+    BaseStepPorts<Record<string, BasePort<{ event?: Event }>>, BasePort<{ event?: Event }>[]>
+  > {
   type: string;
 }

--- a/packages/base-types/src/node/_v1.ts
+++ b/packages/base-types/src/node/_v1.ts
@@ -1,6 +1,6 @@
 import { Nullable } from '@base-types/types';
 
-import { BaseEvent, BaseNode, BasePort, BaseStep, BaseStepPorts, NodeID } from './utils';
+import { BaseEvent, BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeID } from './utils';
 
 export const _V1_STOP_TYPES = 'stopTypes';
 
@@ -9,6 +9,16 @@ export interface StepData<Payload = unknown> {
   stop?: boolean;
   payload: Payload;
   defaultPath?: number;
+}
+
+export interface StepPort<Event = BaseEvent> extends BasePort {
+  data: { event?: Event };
+}
+
+export interface StepPorts<Event> extends BaseStepPorts<Record<string, StepPort<Event>>, StepPort<Event>[]> {}
+
+export interface Step<Payload = unknown, Event = BaseEvent> extends BaseStep<StepData<Payload>, StepPorts<Event>, BasePortList<StepPort<Event>>> {
+  type: string;
 }
 
 export interface NodePath<Event = BaseEvent> {
@@ -23,13 +33,4 @@ export interface Node<Event = BaseEvent> extends BaseNode {
   paths: Array<NodePath<Event>>;
   payload: unknown;
   defaultPath?: number; // index starting from 0
-}
-
-export interface Step<Payload = unknown, Event = BaseEvent>
-  extends BaseStep<
-    StepData<Payload>,
-    BasePort<{ event?: Event }>[],
-    BaseStepPorts<Record<string, BasePort<{ event?: Event }>>, BasePort<{ event?: Event }>[]>
-  > {
-  type: string;
 }

--- a/packages/base-types/src/node/api.ts
+++ b/packages/base-types/src/node/api.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BasePortList, BaseStep, IntegrationType, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
+import { BaseStep, IntegrationType, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export interface APIKeyVal {
   key: string;
@@ -48,7 +48,7 @@ export interface StepData {
   selectedIntegration: IntegrationType.CUSTOM_API;
 }
 
-export type StepPorts = SuccessFailStepPorts;
+export interface StepPorts extends SuccessFailStepPorts<[]> {}
 
 export interface NodeData extends NodeSuccessFailID {
   action_data: {
@@ -66,6 +66,6 @@ export interface NodeData extends NodeSuccessFailID {
   selected_integration: IntegrationType.CUSTOM_API;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.API;
 }

--- a/packages/base-types/src/node/api.ts
+++ b/packages/base-types/src/node/api.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseStep, IntegrationType, NodeSuccessFailID } from './utils';
+import { BasePortList, BaseStep, IntegrationType, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export interface APIKeyVal {
   key: string;
@@ -48,6 +48,8 @@ export interface StepData {
   selectedIntegration: IntegrationType.CUSTOM_API;
 }
 
+export type StepPorts = SuccessFailStepPorts;
+
 export interface NodeData extends NodeSuccessFailID {
   action_data: {
     url: string;
@@ -64,6 +66,6 @@ export interface NodeData extends NodeSuccessFailID {
   selected_integration: IntegrationType.CUSTOM_API;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.API;
 }

--- a/packages/base-types/src/node/buttons.ts
+++ b/packages/base-types/src/node/buttons.ts
@@ -1,19 +1,8 @@
-import { PortType } from '@base-types/models';
 import { Nullable } from '@base-types/types';
 
 import { StepButtonsLayout } from '../button';
 import { NodeType } from './constants';
-import {
-  BaseNoMatchStepData,
-  BaseNoReplyStepData,
-  BasePort,
-  BasePortList,
-  BaseStep,
-  BaseStepNoMatch,
-  BaseStepPorts,
-  DataID,
-  StepIntentScope,
-} from './utils';
+import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch, DataID, NoMatchNoReplyStepPorts, StepIntentScope } from './utils';
 
 export enum ButtonAction {
   URL = 'URL',
@@ -38,8 +27,8 @@ export interface StepData extends StepButtonsLayout, BaseNoReplyStepData, StepIn
   else?: BaseStepNoMatch;
 }
 
-export interface StepPorts extends BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, BasePort[]> {}
+export interface StepPorts extends NoMatchNoReplyStepPorts {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.BUTTONS;
 }

--- a/packages/base-types/src/node/buttons.ts
+++ b/packages/base-types/src/node/buttons.ts
@@ -1,7 +1,8 @@
+import { PortType } from '@base-types/models';
 import { Nullable } from '@base-types/types';
 
 import { StepButtonsLayout } from '../button';
-import { NodeType, PortType } from './constants';
+import { NodeType } from './constants';
 import {
   BaseNoMatchStepData,
   BaseNoReplyStepData,

--- a/packages/base-types/src/node/buttons.ts
+++ b/packages/base-types/src/node/buttons.ts
@@ -1,8 +1,18 @@
 import { Nullable } from '@base-types/types';
 
 import { StepButtonsLayout } from '../button';
-import { NodeType } from './constants';
-import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch, DataID, StepIntentScope } from './utils';
+import { NodeType, PortType } from './constants';
+import {
+  BaseNoMatchStepData,
+  BaseNoReplyStepData,
+  BasePort,
+  BasePortList,
+  BaseStep,
+  BaseStepNoMatch,
+  BaseStepPorts,
+  DataID,
+  StepIntentScope,
+} from './utils';
 
 export enum ButtonAction {
   URL = 'URL',
@@ -27,6 +37,8 @@ export interface StepData extends StepButtonsLayout, BaseNoReplyStepData, StepIn
   else?: BaseStepNoMatch;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export interface StepPorts extends BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, BasePort[]> {}
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.BUTTONS;
 }

--- a/packages/base-types/src/node/capture.ts
+++ b/packages/base-types/src/node/capture.ts
@@ -1,8 +1,16 @@
-import { PortType } from '@base-types/models';
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseNode, BaseNoReplyNodeData, BaseNoReplyStepData, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeNextID } from './utils';
+import {
+  BaseNode,
+  BaseNoReplyNodeData,
+  BaseNoReplyStepData,
+  BaseStep,
+  BaseStepPorts,
+  BuiltInNextPort,
+  BuiltInNoReplyPort,
+  NodeNextID,
+} from './utils';
 
 /** @deprecated */
 export interface StepData extends BaseNoReplyStepData {
@@ -11,11 +19,13 @@ export interface StepData extends BaseNoReplyStepData {
   slotInputs: string[];
 }
 
-/** @deprecated */
-export interface StepPorts extends BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.NO_REPLY]?: BasePort }, []> {}
+export interface StepBuiltInPorts extends BuiltInNextPort, BuiltInNoReplyPort {}
 
 /** @deprecated */
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface StepPorts extends BaseStepPorts<StepBuiltInPorts, []> {}
+
+/** @deprecated */
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.CAPTURE;
 }
 

--- a/packages/base-types/src/node/capture.ts
+++ b/packages/base-types/src/node/capture.ts
@@ -1,7 +1,8 @@
+import { PortType } from '@base-types/models';
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseNode, BaseNoReplyNodeData, BaseNoReplyStepData, BaseStep, NodeNextID } from './utils';
+import { BaseNode, BaseNoReplyNodeData, BaseNoReplyStepData, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeNextID } from './utils';
 
 /** @deprecated */
 export interface StepData extends BaseNoReplyStepData {
@@ -11,7 +12,10 @@ export interface StepData extends BaseNoReplyStepData {
 }
 
 /** @deprecated */
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export interface StepPorts extends BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.NO_REPLY]?: BasePort }, []> {}
+
+/** @deprecated */
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.CAPTURE;
 }
 

--- a/packages/base-types/src/node/captureV2.ts
+++ b/packages/base-types/src/node/captureV2.ts
@@ -1,4 +1,4 @@
-import { Intent, PortType } from '@base-types/models';
+import { Intent } from '@base-types/models';
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
@@ -8,10 +8,10 @@ import {
   BaseNoMatchStepData,
   BaseNoReplyNodeData,
   BaseNoReplyStepData,
-  BasePort,
-  BasePortList,
   BaseStep,
   BaseStepPorts,
+  BuiltInNextPort,
+  BuiltInNoMatchNoReplyPorts,
   NodeIntentScope,
   NodeNextID,
   StepIntentScope,
@@ -38,9 +38,11 @@ export interface StepData extends BaseCaptureData {
   capture: IntentCapture | QueryCapture;
 }
 
-export interface StepPorts extends BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, []> {}
+export interface StepBuiltInPorts extends BuiltInNextPort, BuiltInNoMatchNoReplyPorts {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface StepPorts extends BaseStepPorts<StepBuiltInPorts, []> {}
+
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.CAPTURE_V2;
 }
 

--- a/packages/base-types/src/node/captureV2.ts
+++ b/packages/base-types/src/node/captureV2.ts
@@ -1,14 +1,17 @@
 import { Intent } from '@base-types/models';
 import { Nullable } from '@base-types/types';
 
-import { NodeType } from './constants';
+import { NodeType, PortType } from './constants';
 import {
   BaseNode,
   BaseNoMatchNodeData,
   BaseNoMatchStepData,
   BaseNoReplyNodeData,
   BaseNoReplyStepData,
+  BasePort,
+  BasePortList,
   BaseStep,
+  BaseStepPorts,
   NodeIntentScope,
   NodeNextID,
   StepIntentScope,
@@ -34,7 +37,10 @@ export interface QueryCapture {
 export interface StepData extends BaseCaptureData {
   capture: IntentCapture | QueryCapture;
 }
-export interface Step<Data = StepData> extends BaseStep<Data> {
+
+export interface StepPorts extends BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, []> {}
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.CAPTURE_V2;
 }
 

--- a/packages/base-types/src/node/captureV2.ts
+++ b/packages/base-types/src/node/captureV2.ts
@@ -1,7 +1,7 @@
-import { Intent } from '@base-types/models';
+import { Intent, PortType } from '@base-types/models';
 import { Nullable } from '@base-types/types';
 
-import { NodeType, PortType } from './constants';
+import { NodeType } from './constants';
 import {
   BaseNode,
   BaseNoMatchNodeData,

--- a/packages/base-types/src/node/code.ts
+++ b/packages/base-types/src/node/code.ts
@@ -1,11 +1,13 @@
 import { NodeType } from './constants';
-import { BaseNode, BaseStep, NodeSuccessFailID } from './utils';
+import { BaseNode, BasePortList, BaseStep, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export interface StepData {
   code: string;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export type StepPorts = SuccessFailStepPorts;
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.CODE;
 }
 

--- a/packages/base-types/src/node/code.ts
+++ b/packages/base-types/src/node/code.ts
@@ -1,13 +1,13 @@
 import { NodeType } from './constants';
-import { BaseNode, BasePortList, BaseStep, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
+import { BaseNode, BaseStep, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export interface StepData {
   code: string;
 }
 
-export type StepPorts = SuccessFailStepPorts;
+export interface StepPorts extends SuccessFailStepPorts<[]> {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.CODE;
 }
 

--- a/packages/base-types/src/node/constants.ts
+++ b/packages/base-types/src/node/constants.ts
@@ -43,12 +43,3 @@ export enum NodeType {
 }
 
 export const RUNTIME_ONLY_NODES = [NodeType.GOTO] as const;
-
-export enum PortType {
-  FAIL = 'fail',
-  NEXT = 'next',
-  PAUSE = 'pause',
-  NO_REPLY = 'no-reply',
-  NO_MATCH = 'else',
-  PREVIOUS = 'previous',
-}

--- a/packages/base-types/src/node/constants.ts
+++ b/packages/base-types/src/node/constants.ts
@@ -43,3 +43,12 @@ export enum NodeType {
 }
 
 export const RUNTIME_ONLY_NODES = [NodeType.GOTO] as const;
+
+export enum PortType {
+  FAIL = 'fail',
+  NEXT = 'next',
+  PAUSE = 'pause',
+  NO_REPLY = 'no-reply',
+  NO_MATCH = 'else',
+  PREVIOUS = 'previous',
+}

--- a/packages/base-types/src/node/exit.ts
+++ b/packages/base-types/src/node/exit.ts
@@ -9,7 +9,7 @@ export interface NodeData {
   end: true;
 }
 
-export type StepPorts = EmptyStepPorts;
+export interface StepPorts extends EmptyStepPorts {}
 
 export interface Step<Data = StepData> extends BaseStep<Data, [], StepPorts> {
   type: NodeType.EXIT;

--- a/packages/base-types/src/node/exit.ts
+++ b/packages/base-types/src/node/exit.ts
@@ -1,7 +1,7 @@
 import { UnknownRecord } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseNode, BaseStep, BaseTraceFrame, TraceType } from './utils';
+import { BaseNode, BaseStep, BaseTraceFrame, EmptyStepPorts, TraceType } from './utils';
 
 export type StepData = UnknownRecord;
 
@@ -9,7 +9,9 @@ export interface NodeData {
   end: true;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export type StepPorts = EmptyStepPorts;
+
+export interface Step<Data = StepData> extends BaseStep<Data, [], StepPorts> {
   type: NodeType.EXIT;
 }
 

--- a/packages/base-types/src/node/googleSheets.ts
+++ b/packages/base-types/src/node/googleSheets.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BasePortList, BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
+import { BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export enum GoogleSheetsActionType {
   CREATE_DATA = 'Create Data',
@@ -40,9 +40,9 @@ export interface StepData {
   selectedIntegration: IntegrationType.GOOGLE_SHEETS;
 }
 
-export type StepPorts = SuccessFailStepPorts;
+export interface StepPorts extends SuccessFailStepPorts<[]> {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.GOOGLE_SHEETS;
 }
 

--- a/packages/base-types/src/node/googleSheets.ts
+++ b/packages/base-types/src/node/googleSheets.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID } from './utils';
+import { BasePortList, BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export enum GoogleSheetsActionType {
   CREATE_DATA = 'Create Data',
@@ -40,7 +40,9 @@ export interface StepData {
   selectedIntegration: IntegrationType.GOOGLE_SHEETS;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export type StepPorts = SuccessFailStepPorts;
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.GOOGLE_SHEETS;
 }
 

--- a/packages/base-types/src/node/if.ts
+++ b/packages/base-types/src/node/if.ts
@@ -1,15 +1,13 @@
-import { PortType } from '@base-types/models';
-
 import { NodeType } from './constants';
-import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, Expression, NodeElseID, NodeNextIDs } from './utils';
+import { BaseNode, BaseStep, BaseStepPorts, BuiltInNoMatchPort, Expression, NodeElseID, NodeNextIDs } from './utils';
 
 export interface StepData {
   expressions: Expression[];
 }
 
-export interface StepPorts extends BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort }, BasePort[]> {}
+export interface StepPorts extends BaseStepPorts<BuiltInNoMatchPort> {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.IF;
 }
 

--- a/packages/base-types/src/node/if.ts
+++ b/packages/base-types/src/node/if.ts
@@ -1,11 +1,15 @@
+import { EmptyRecord } from '@base-types/types';
+
 import { NodeType } from './constants';
-import { BaseNode, BaseStep, Expression, NodeElseID, NodeNextIDs } from './utils';
+import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, Expression, NodeElseID, NodeNextIDs } from './utils';
 
 export interface StepData {
   expressions: Expression[];
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export interface StepPorts extends BaseStepPorts<EmptyRecord, BasePort[]> {}
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.IF;
 }
 

--- a/packages/base-types/src/node/if.ts
+++ b/packages/base-types/src/node/if.ts
@@ -1,4 +1,4 @@
-import { EmptyRecord } from '@base-types/types';
+import { PortType } from '@base-types/models';
 
 import { NodeType } from './constants';
 import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, Expression, NodeElseID, NodeNextIDs } from './utils';
@@ -7,7 +7,7 @@ export interface StepData {
   expressions: Expression[];
 }
 
-export interface StepPorts extends BaseStepPorts<EmptyRecord, BasePort[]> {}
+export interface StepPorts extends BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort }, BasePort[]> {}
 
 export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.IF;

--- a/packages/base-types/src/node/ifV2.ts
+++ b/packages/base-types/src/node/ifV2.ts
@@ -1,6 +1,6 @@
 import { NodePath } from './_v1';
-import { NodeType } from './constants';
-import { BaseNode, BaseStep, ExpressionData, NodeElseID } from './utils';
+import { NodeType, PortType } from './constants';
+import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, ExpressionData, NodeElseID } from './utils';
 
 export enum IfNoMatchType {
   PATH = 'path',
@@ -17,7 +17,9 @@ export interface StepData {
   noMatch?: IfNoMatch;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export interface StepPorts extends BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort }, BasePort[]> {}
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.IF_V2;
 }
 

--- a/packages/base-types/src/node/ifV2.ts
+++ b/packages/base-types/src/node/ifV2.ts
@@ -1,5 +1,7 @@
+import { PortType } from '@base-types/models';
+
 import { NodePath } from './_v1';
-import { NodeType, PortType } from './constants';
+import { NodeType } from './constants';
 import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, ExpressionData, NodeElseID } from './utils';
 
 export enum IfNoMatchType {

--- a/packages/base-types/src/node/ifV2.ts
+++ b/packages/base-types/src/node/ifV2.ts
@@ -1,8 +1,6 @@
-import { PortType } from '@base-types/models';
-
 import { NodePath } from './_v1';
 import { NodeType } from './constants';
-import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, ExpressionData, NodeElseID } from './utils';
+import { BaseNode, BaseStep, BaseStepPorts, BuiltInNoMatchPort, ExpressionData, NodeElseID } from './utils';
 
 export enum IfNoMatchType {
   PATH = 'path',
@@ -19,9 +17,9 @@ export interface StepData {
   noMatch?: IfNoMatch;
 }
 
-export interface StepPorts extends BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort }, BasePort[]> {}
+export interface StepPorts extends BaseStepPorts<BuiltInNoMatchPort> {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.IF_V2;
 }
 

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -1,7 +1,7 @@
 import { AnyRequestButton } from '@base-types/request';
 import { Nullable } from '@base-types/types';
 
-import { NodeType } from './constants';
+import { NodeType, PortType } from './constants';
 import {
   BaseEvent,
   BaseNode,
@@ -9,8 +9,11 @@ import {
   BaseNoMatchStepData,
   BaseNoReplyNodeData,
   BaseNoReplyStepData,
+  BasePort,
+  BasePortList,
   BaseStep,
   BaseStepNoMatch,
+  BaseStepPorts,
   BaseTraceFrame,
   DeprecatedBaseNodeNoMatch,
   NodeIntentScope,
@@ -46,7 +49,9 @@ export interface StepData extends BaseNoReplyStepData, StepIntentScope, BaseNoMa
   else?: BaseStepNoMatch;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export type StepPorts = BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, BasePort[]>;
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.INTERACTION;
 }
 

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -1,7 +1,8 @@
+import { PortType } from '@base-types/models';
 import { AnyRequestButton } from '@base-types/request';
 import { Nullable } from '@base-types/types';
 
-import { NodeType, PortType } from './constants';
+import { NodeType } from './constants';
 import {
   BaseEvent,
   BaseNode,

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -1,4 +1,3 @@
-import { PortType } from '@base-types/models';
 import { AnyRequestButton } from '@base-types/request';
 import { Nullable } from '@base-types/types';
 
@@ -10,15 +9,13 @@ import {
   BaseNoMatchStepData,
   BaseNoReplyNodeData,
   BaseNoReplyStepData,
-  BasePort,
-  BasePortList,
   BaseStep,
   BaseStepNoMatch,
-  BaseStepPorts,
   BaseTraceFrame,
   DeprecatedBaseNodeNoMatch,
   NodeIntentScope,
   NodeNextID,
+  NoMatchNoReplyStepPorts,
   SlotMappings,
   StepIntentScope,
   TraceType,
@@ -50,9 +47,9 @@ export interface StepData extends BaseNoReplyStepData, StepIntentScope, BaseNoMa
   else?: BaseStepNoMatch;
 }
 
-export type StepPorts = BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, BasePort[]>;
+export interface StepPorts extends NoMatchNoReplyStepPorts {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.INTERACTION;
 }
 

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -50,7 +50,7 @@ export interface StepData extends BaseNoReplyStepData, StepIntentScope, BaseNoMa
   else?: BaseStepNoMatch;
 }
 
-export type StepPorts = BaseStepPorts<{ [PortType.NEXT]: BasePort; [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, BasePort[]>;
+export type StepPorts = BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, BasePort[]>;
 
 export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.INTERACTION;

--- a/packages/base-types/src/node/prompt.ts
+++ b/packages/base-types/src/node/prompt.ts
@@ -1,5 +1,5 @@
 import { NodeType } from './constants';
-import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch } from './utils';
+import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch, EmptyStepPorts } from './utils';
 
 export interface StepData extends BaseNoReplyStepData, BaseNoMatchStepData {
   /**
@@ -8,6 +8,8 @@ export interface StepData extends BaseNoReplyStepData, BaseNoMatchStepData {
   noMatches?: BaseStepNoMatch;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data, []> {
+export type StepPorts = EmptyStepPorts;
+
+export interface Step<Data = StepData> extends BaseStep<Data, [], StepPorts> {
   type: NodeType.PROMPT;
 }

--- a/packages/base-types/src/node/prompt.ts
+++ b/packages/base-types/src/node/prompt.ts
@@ -1,7 +1,5 @@
-import { BasePort, BasePortList, PortType } from '@base-types/models';
-
 import { NodeType } from './constants';
-import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch, BaseStepPorts } from './utils';
+import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch, NoMatchNoReplyStepPorts } from './utils';
 
 export interface StepData extends BaseNoReplyStepData, BaseNoMatchStepData {
   /**
@@ -10,8 +8,8 @@ export interface StepData extends BaseNoReplyStepData, BaseNoMatchStepData {
   noMatches?: BaseStepNoMatch;
 }
 
-export type StepPorts = BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, []>;
+export interface StepPorts extends NoMatchNoReplyStepPorts<[]> {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.PROMPT;
 }

--- a/packages/base-types/src/node/prompt.ts
+++ b/packages/base-types/src/node/prompt.ts
@@ -1,5 +1,7 @@
+import { BasePort, BasePortList, PortType } from '@base-types/models';
+
 import { NodeType } from './constants';
-import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch, EmptyStepPorts } from './utils';
+import { BaseNoMatchStepData, BaseNoReplyStepData, BaseStep, BaseStepNoMatch, BaseStepPorts } from './utils';
 
 export interface StepData extends BaseNoReplyStepData, BaseNoMatchStepData {
   /**
@@ -8,8 +10,8 @@ export interface StepData extends BaseNoReplyStepData, BaseNoMatchStepData {
   noMatches?: BaseStepNoMatch;
 }
 
-export type StepPorts = EmptyStepPorts;
+export type StepPorts = BaseStepPorts<{ [PortType.NO_MATCH]?: BasePort; [PortType.NO_REPLY]?: BasePort }, []>;
 
-export interface Step<Data = StepData> extends BaseStep<Data, [], StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.PROMPT;
 }

--- a/packages/base-types/src/node/random.ts
+++ b/packages/base-types/src/node/random.ts
@@ -1,7 +1,5 @@
-import { EmptyRecord } from '@base-types/types';
-
 import { NodeType } from './constants';
-import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeNextIDs } from './utils';
+import { BaseNode, BaseStep, DynamicOnlyStepPorts, NodeNextIDs } from './utils';
 
 export enum RandomType {
   DEFAULT = 1,
@@ -13,9 +11,9 @@ export interface StepData {
   noDuplicates: boolean;
 }
 
-export type StepPorts = BaseStepPorts<EmptyRecord, BasePort[]>;
+export interface StepPorts extends DynamicOnlyStepPorts {}
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.RANDOM;
 }
 

--- a/packages/base-types/src/node/random.ts
+++ b/packages/base-types/src/node/random.ts
@@ -1,5 +1,7 @@
+import { EmptyRecord } from '@base-types/types';
+
 import { NodeType } from './constants';
-import { BaseNode, BaseStep, NodeNextIDs } from './utils';
+import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeNextIDs } from './utils';
 
 export enum RandomType {
   DEFAULT = 1,
@@ -11,7 +13,9 @@ export interface StepData {
   noDuplicates: boolean;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export type StepPorts = BaseStepPorts<EmptyRecord, BasePort[]>;
+
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.RANDOM;
 }
 

--- a/packages/base-types/src/node/stream.ts
+++ b/packages/base-types/src/node/stream.ts
@@ -1,6 +1,6 @@
-import { EmptyRecord } from '@base-types/types';
+import { PortType } from '@base-types/models';
 
-import { NodeType, PortType } from './constants';
+import { NodeType } from './constants';
 import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, BaseTraceFrame, NodeID, TraceType } from './utils';
 
 export interface StepData {
@@ -15,7 +15,8 @@ export enum TraceStreamAction {
   PAUSE = 'PAUSE',
 }
 
-export interface StepPorts<BP extends Record<string, BasePort> = EmptyRecord> extends BaseStepPorts<{ [PortType.NEXT]: BasePort } & BP, []> {}
+export interface StepPorts<BP extends Record<string, BasePort> = { [PortType.PREVIOUS]?: BasePort; [PortType.PAUSE]?: BasePort }>
+  extends BaseStepPorts<{ [PortType.NEXT]: BasePort } & BP, []> {}
 
 export interface Step<Data = StepData, Ports = StepPorts> extends BaseStep<Data, BasePortList, Ports> {
   type: NodeType.STREAM;

--- a/packages/base-types/src/node/stream.ts
+++ b/packages/base-types/src/node/stream.ts
@@ -1,5 +1,7 @@
-import { NodeType } from './constants';
-import { BaseNode, BaseStep, BaseTraceFrame, NodeID, TraceType } from './utils';
+import { EmptyRecord } from '@base-types/types';
+
+import { NodeType, PortType } from './constants';
+import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, BaseTraceFrame, NodeID, TraceType } from './utils';
 
 export interface StepData {
   src: string;
@@ -13,7 +15,9 @@ export enum TraceStreamAction {
   PAUSE = 'PAUSE',
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export interface StepPorts<BP extends Record<string, BasePort> = EmptyRecord> extends BaseStepPorts<{ [PortType.NEXT]: BasePort } & BP, []> {}
+
+export interface Step<Data = StepData, Ports = StepPorts> extends BaseStep<Data, BasePortList, Ports> {
   type: NodeType.STREAM;
 }
 

--- a/packages/base-types/src/node/stream.ts
+++ b/packages/base-types/src/node/stream.ts
@@ -1,7 +1,7 @@
 import { PortType } from '@base-types/models';
 
 import { NodeType } from './constants';
-import { BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, BaseTraceFrame, NodeID, TraceType } from './utils';
+import { BaseNode, BasePort, BaseStep, BaseStepPorts, BaseTraceFrame, BuiltInNextPort, NodeID, TraceType } from './utils';
 
 export interface StepData {
   src: string;
@@ -15,10 +15,16 @@ export enum TraceStreamAction {
   PAUSE = 'PAUSE',
 }
 
-export interface StepPorts<BP extends Record<string, BasePort> = { [PortType.PREVIOUS]?: BasePort; [PortType.PAUSE]?: BasePort }>
-  extends BaseStepPorts<{ [PortType.NEXT]: BasePort } & BP, []> {}
+export interface StepBaseBuiltInPorts extends BuiltInNextPort {}
 
-export interface Step<Data = StepData, Ports = StepPorts> extends BaseStep<Data, BasePortList, Ports> {
+export interface StepDefaultBuiltPorts extends StepBaseBuiltInPorts {
+  [PortType.PAUSE]?: BasePort;
+  [PortType.PREVIOUS]?: BasePort;
+}
+
+export interface StepPorts<BuiltInPorts extends StepBaseBuiltInPorts = StepDefaultBuiltPorts> extends BaseStepPorts<BuiltInPorts, []> {}
+
+export interface Step<Data = StepData, Ports = StepPorts> extends BaseStep<Data, Ports> {
   type: NodeType.STREAM;
 }
 

--- a/packages/base-types/src/node/utils/base.ts
+++ b/packages/base-types/src/node/utils/base.ts
@@ -7,8 +7,16 @@ export {
   BasePortList,
   BaseStep,
   BaseStepPorts,
+  BuiltInFailPort,
+  BuiltInNextFailPorts,
+  BuiltInNextPort,
+  BuiltInNoMatchNoReplyPorts,
+  BuiltInNoMatchPort,
+  BuiltInNoReplyPort,
+  DynamicOnlyStepPorts,
   EmptyStepPorts,
   NextStepPorts,
+  NoMatchNoReplyStepPorts,
   SuccessFailStepPorts,
 } from '@base-types/models';
 

--- a/packages/base-types/src/node/utils/base.ts
+++ b/packages/base-types/src/node/utils/base.ts
@@ -1,6 +1,16 @@
 import { Nullable } from '@base-types/types';
 
-export { BaseCommand, BaseNode, BasePort, BaseStep } from '@base-types/models';
+export {
+  BaseCommand,
+  BaseNode,
+  BasePort,
+  BasePortList,
+  BaseStep,
+  BaseStepPorts,
+  EmptyStepPorts,
+  NextStepPorts,
+  SuccessFailStepPorts,
+} from '@base-types/models';
 
 export type NodeID = Nullable<string>;
 

--- a/packages/base-types/src/node/zapier.ts
+++ b/packages/base-types/src/node/zapier.ts
@@ -1,5 +1,5 @@
 import { NodeType } from './constants';
-import { BasePortList, BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
+import { BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export enum ZapierActionType {
   START_A_ZAP = 'Start a Zap',
@@ -12,7 +12,7 @@ export interface StepData {
   selectedIntegration: IntegrationType.ZAPIER;
 }
 
-export type StepPorts = SuccessFailStepPorts;
+export interface StepPorts extends SuccessFailStepPorts<[]> {}
 
 export interface ActionData {
   user?: IntegrationUser;
@@ -25,6 +25,6 @@ export interface NodeData extends NodeSuccessFailID {
   selected_integration: IntegrationType.ZAPIER;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
+export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.ZAPIER;
 }

--- a/packages/base-types/src/node/zapier.ts
+++ b/packages/base-types/src/node/zapier.ts
@@ -1,5 +1,5 @@
 import { NodeType } from './constants';
-import { BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID } from './utils';
+import { BasePortList, BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
 
 export enum ZapierActionType {
   START_A_ZAP = 'Start a Zap',
@@ -12,6 +12,8 @@ export interface StepData {
   selectedIntegration: IntegrationType.ZAPIER;
 }
 
+export type StepPorts = SuccessFailStepPorts;
+
 export interface ActionData {
   user?: IntegrationUser;
   value: string;
@@ -23,6 +25,6 @@ export interface NodeData extends NodeSuccessFailID {
   selected_integration: IntegrationType.ZAPIER;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data> {
+export interface Step<Data = StepData> extends BaseStep<Data, BasePortList, StepPorts> {
   type: NodeType.ZAPIER;
 }

--- a/packages/base-types/src/types.ts
+++ b/packages/base-types/src/types.ts
@@ -4,6 +4,8 @@ export type AnyRecord = Record<string, any>;
 
 export type UnknownRecord = Record<string, unknown>;
 
+export type EmptyRecord = Record<string, never>;
+
 export type DeepPartialByKey<T, K extends keyof T> = {
   [P in keyof T]?: P extends K ? Partial<T[P]> : T[P];
 };

--- a/packages/google-types/src/node/stream.ts
+++ b/packages/google-types/src/node/stream.ts
@@ -1,4 +1,4 @@
-import { BaseNode, EmptyRecord } from '@voiceflow/base-types';
+import { BaseNode } from '@voiceflow/base-types';
 
 export interface StepData {
   loop: boolean;
@@ -9,7 +9,7 @@ export interface StepData {
   backgroundImage?: string;
 }
 
-export interface StepPorts extends BaseNode.Stream.StepPorts<EmptyRecord> {}
+export interface StepPorts extends BaseNode.Stream.StepPorts<BaseNode.Stream.StepBaseBuiltInPorts> {}
 
 export interface Step extends BaseNode.Stream.Step<StepData, StepPorts> {}
 

--- a/packages/google-types/src/node/stream.ts
+++ b/packages/google-types/src/node/stream.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, EmptyRecord } from '@voiceflow/base-types';
 
 export interface StepData {
   loop: boolean;
@@ -9,7 +9,9 @@ export interface StepData {
   backgroundImage?: string;
 }
 
-export interface Step extends BaseNode.Stream.Step<StepData> {}
+export interface StepPorts extends BaseNode.Stream.StepPorts<EmptyRecord> {}
+
+export interface Step extends BaseNode.Stream.Step<StepData, StepPorts> {}
 
 export interface Node extends Pick<BaseNode.Stream.Node, keyof BaseNode.Utils.BaseNode> {
   loop: boolean;

--- a/packages/voiceflow-types/src/node/buttons/index.ts
+++ b/packages/voiceflow-types/src/node/buttons/index.ts
@@ -1,3 +1,5 @@
+import { BaseNode } from '@voiceflow/base-types';
+
 import { ChatStep, ChatStepData } from './chat';
 import { VoiceStep, VoiceStepData } from './voice';
 
@@ -5,4 +7,5 @@ export * from './chat';
 export * from './voice';
 
 export type Step = ChatStep | VoiceStep;
+export type StepPorts = BaseNode.Buttons.StepPorts;
 export type StepData = ChatStepData | VoiceStepData;

--- a/packages/voiceflow-types/src/node/capture/index.ts
+++ b/packages/voiceflow-types/src/node/capture/index.ts
@@ -1,3 +1,5 @@
+import { BaseNode } from '@voiceflow/base-types';
+
 import { ChatNode, ChatStep, ChatStepData } from './chat';
 import { VoiceNode, VoiceStep, VoiceStepData } from './voice';
 
@@ -6,6 +8,9 @@ export * from './voice';
 
 /** @deprecated */
 export type Step = ChatStep | VoiceStep;
+
+/** @deprecated */
+export type StepPorts = BaseNode.Capture.StepPorts;
 
 /** @deprecated */
 export type StepData = ChatStepData | VoiceStepData;

--- a/packages/voiceflow-types/src/node/captureV2/index.ts
+++ b/packages/voiceflow-types/src/node/captureV2/index.ts
@@ -1,3 +1,5 @@
+import { BaseNode } from '@voiceflow/base-types';
+
 import { ChatNode, ChatStep, ChatStepData } from './chat';
 import { VoiceNode, VoiceStep, VoiceStepData } from './voice';
 
@@ -5,6 +7,8 @@ export * from './chat';
 export * from './voice';
 
 export type Step = ChatStep | VoiceStep;
+
+export type StepPorts = BaseNode.CaptureV2.StepPorts;
 
 export type StepData = ChatStepData | VoiceStepData;
 

--- a/packages/voiceflow-types/src/node/interaction/index.ts
+++ b/packages/voiceflow-types/src/node/interaction/index.ts
@@ -1,3 +1,5 @@
+import { BaseNode } from '@voiceflow/base-types';
+
 import { ChatNode, ChatStep, ChatStepData } from './chat';
 import { VoiceNode, VoiceStep, VoiceStepData } from './voice';
 
@@ -5,6 +7,8 @@ export * from './chat';
 export * from './voice';
 
 export type Step = ChatStep | VoiceStep;
+
+export type StepPorts = BaseNode.Interaction.StepPorts;
 
 export type StepData = ChatStepData | VoiceStepData;
 

--- a/packages/voiceflow-types/src/node/prompt/index.ts
+++ b/packages/voiceflow-types/src/node/prompt/index.ts
@@ -1,3 +1,5 @@
+import { BaseNode } from '@voiceflow/base-types';
+
 import { ChatStep, ChatStepData } from './chat';
 import { VoiceStep, VoiceStepData } from './voice';
 
@@ -5,4 +7,5 @@ export * from './chat';
 export * from './voice';
 
 export type Step = ChatStep | VoiceStep;
+export type StepPorts = BaseNode.Prompt.StepPorts;
 export type StepData = ChatStepData | VoiceStepData;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3082**

### Brief description. What is this change?

Add support for handling steps with the now-legacy `ports` property or with the new `portsV2` property.

### Related PRs

<!-- List related PRs against other branches -->

voiceflow/database-cli#185
voiceflow/general-service#295
voiceflow/google-service#234
voiceflow/alexa-service#255

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
