### PR TITLE
[Merged by Bors] - fix: write tests for Utils.array.reorder (VF-000)

### DIFF
--- a/packages/common/src/utils/array.ts
+++ b/packages/common/src/utils/array.ts
@@ -37,7 +37,7 @@ export const reorder = <T>(items: T[], fromIndex: number, toIndex: number): T[] 
     return items;
   }
 
-  if (toIndex < 0) {
+  if (toIndex <= 0) {
     return [items[fromIndex], ...without(items, fromIndex)];
   }
 

--- a/packages/common/tests/utils/array.unit.ts
+++ b/packages/common/tests/utils/array.unit.ts
@@ -6,6 +6,7 @@ import {
   insertAll,
   isNotNullish,
   isNullish,
+  reorder,
   replace,
   tail,
   toArray,
@@ -145,6 +146,37 @@ describe('Utils | array', () => {
       const value = 1;
 
       expect(toArray(value)).to.eql([1]);
+    });
+  });
+
+  describe('reorder()', () => {
+    it('should do nothing if from index goes outside array', () => {
+      const array = [1, 2, 3];
+      expect(reorder(array, -1, 1)).to.eql(array);
+      expect(reorder(array, 3, 1)).to.eql(array);
+    });
+    it('should set as first item if toIndex is zero or lower than 0', () => {
+      const array = [1, 2, 3];
+
+      expect(reorder(array, 2, -1)).to.eql([3, 1, 2]);
+      expect(reorder(array, 2, 0)).to.eql([3, 1, 2]);
+    });
+    it('should set as last item if toIndex is the last or greater than last', () => {
+      const array = [1, 2, 3];
+
+      expect(reorder(array, 0, 2)).to.eql([2, 3, 1]);
+      expect(reorder(array, 0, 3)).to.eql([2, 3, 1]);
+    });
+
+    it('should reorder moving forward or backward', () => {
+      const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+      expect(reorder(array, 1, 2)).to.eql([1, 3, 2, 4, 5, 6, 7, 8, 9, 10]);
+      expect(reorder(array, 2, 3)).to.eql([1, 2, 4, 3, 5, 6, 7, 8, 9, 10]);
+      expect(reorder(array, 2, 8)).to.eql([1, 2, 4, 5, 6, 7, 8, 9, 3, 10]);
+
+      expect(reorder(array, 8, 1)).to.eql([1, 9, 2, 3, 4, 5, 6, 7, 8, 10]);
+      expect(reorder(array, 7, 2)).to.eql([1, 2, 8, 3, 4, 5, 6, 7, 9, 10]);
     });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
Was debugging an issue with array ordering and noticed we didn't have unit tests for this function.

 - Add unit tests to Utils.array.reorder fn.
 - Optimize reorder when moving to the first position of the array.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [X] appropriate tests have been written
