### PR TITLE
[Merged by Bors] - feat: slot annotation map utility (VF-000)

### DIFF
--- a/packages/common/src/utils/slot.ts
+++ b/packages/common/src/utils/slot.ts
@@ -1,5 +1,7 @@
 import _uniqBy from 'lodash/uniqBy';
 
+import { SLOT_REGEXP } from '../constants';
+
 export const addPrebuiltEntities = <A extends { key: string; inputs: string[] }>(entities: A[], prebuiltEntities: Record<string, string[]>): A[] =>
   entities.map((entity) => {
     if (prebuiltEntities[entity.key]) {
@@ -15,3 +17,27 @@ export const getUniqueSamples = (input: string) => _uniqBy(input.split(','), (sa
 
 // spread all synonyms into string array ['car, automobile', 'plane, jet'] => ['car', 'automobile', 'plane', 'jet']
 export const getAllSamples = (inputs: string[] = []) => inputs.flatMap((input) => input.split(',')).filter((sample) => !!sample.trim());
+
+/**
+ * Return a tuple of synonyms, the first value being the first synonym, the next being the remaining synonyms
+ */
+export const getValueWithSynonyms = (input: string): [string, string[]] => {
+  const [value, ...synonyms] = input.split(',').map((str) => str.trim());
+  return [value, synonyms];
+};
+
+/**
+ * Map through all slot annotations in the given string input.
+ * For each annotation, the callbackFn will be called with the slot's key and name, returning a key and name.
+ * @param input String with slot annotations.
+ * @param callbackFn Map function called with the key and name of the slot.
+ * @returns Input with mapped slot annotations
+ * @example const result = mapSlotAnnotations("Hello {{[slot].id}}", ({key, name}) => ({key: key + '2', slot: slot + '2'});
+ * result === "Hello {{[slot2].id2}}"
+ */
+export const mapSlotAnnotations = (input: string, callbackFn: (slot: { key: string; name: string }) => { key: string; name: string }) => {
+  return input.replace(SLOT_REGEXP, (_, slotName, slotKey) => {
+    const { key, name } = callbackFn({ key: slotKey, name: slotName });
+    return `{{[${name}].${key}}}`;
+  });
+};

--- a/packages/common/tests/utils/slot.unit.ts
+++ b/packages/common/tests/utils/slot.unit.ts
@@ -1,0 +1,18 @@
+import * as SlotUtils from '@common/utils/slot';
+import { expect } from 'chai';
+
+describe('Utils | slot', () => {
+  describe('getValueWithSynonyms', () => {
+    it('extracts synonyms', () => {
+      expect(SlotUtils.getValueWithSynonyms('a, b, c, d')).to.eql(['a', ['b', 'c', 'd']]);
+    });
+  });
+
+  describe('mapSlotAnnotations', () => {
+    it('renames keys and maps', () => {
+      expect(SlotUtils.mapSlotAnnotations('test {{[name].key}} thing', () => ({ key: 'newKey', name: 'newName' }))).to.equal(
+        'test {{[newName].newKey}} thing'
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

Provide some additional slot utilities.

`mapSlotAnnotations` lets us remap slot annotation names or keys.

`getValueWithSynonyms` provides an array of slot tuples, the first item being the slot input and the next being the synonyms.