### PR TITLE
[Merged by Bors] - feat: implement new reorderTopics method (VF-3269)

### DIFF
--- a/packages/api-sdk/src/resources/version.ts
+++ b/packages/api-sdk/src/resources/version.ts
@@ -188,6 +188,11 @@ class VersionResource extends CrudResource<BaseModels.Version.Model<BaseModels.V
 
     return data;
   }
+
+  public async reorderTopics<P extends { fromID: string; toIndex: number }>(id: string, body: P): Promise<string> {
+    const { data } = await this.fetch.patch<string>(`${this._getCRUDEndpoint(id)}/topics/reorder`, body);
+    return data;
+  }
 }
 
 export default VersionResource;

--- a/packages/api-sdk/tests/resources/version.unit.ts
+++ b/packages/api-sdk/tests/resources/version.unit.ts
@@ -382,4 +382,23 @@ describe('VersionResource', () => {
     expect(fetch.get.args[0]).to.eql([`versions/${versionID}/prototype/plan`]);
     expect(data).to.eql(response.data);
   });
+
+  it('reorderTopics', async () => {
+    const { fetch, resource } = createClient();
+
+    const fromID = 'fromID-1';
+    const toIndex = 1;
+
+    const response = { data: 'fromID-1' };
+
+    fetch.patch.resolves(response);
+
+    const versionID = '1';
+
+    const data = await resource.reorderTopics(versionID, { fromID, toIndex });
+
+    expect(fetch.patch.callCount).to.eql(1);
+    expect(fetch.patch.args[0]).to.eql([`versions/${versionID}/topics/reorder`, { fromID, toIndex }]);
+    expect(data).to.eql(response.data);
+  });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3269**

### Brief description. What is this change?

Create new reorder topics dedicated endpoint and support it on the api-sdk

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| creator-api | [link](https://github.com/voiceflow/creator-api/pull/959) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [X] appropriate tests have been written
