### PR TITLE
[Merged by Bors] - feat: add schema version to model (VF-3082)

### DIFF
--- a/packages/base-types/src/models/version/index.ts
+++ b/packages/base-types/src/models/version/index.ts
@@ -40,6 +40,7 @@ export interface Folder {
 
 export interface Model<_PlatformData extends PlatformData, Command extends BaseCommand = BaseCommand, Locale extends string = string> {
   _id: string;
+  _version?: number;
   creatorID: number;
   projectID: string;
   rootDiagramID: string;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3082**

### Brief description. What is this change?

Adds a new optional `_version` property to the Version model types

### Related PRs

voiceflow/database-cli#186
voiceflow/creator-api#960
voiceflow/creator-app#5320

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
