### PR TITLE
[Merged by Bors] - fix: fix cardV2 type enum definition (VF-3351)

### DIFF
--- a/packages/base-types/src/node/cardV2.ts
+++ b/packages/base-types/src/node/cardV2.ts
@@ -12,7 +12,7 @@ import {
   NoMatchNoReplyStepPorts,
 } from './utils';
 
-export declare enum CardLayout {
+export enum CardLayout {
   CAROUSEL = 'Carousel',
   LIST = 'List',
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3351**
Enum is used as a value inside node factory