### PR TITLE
[Merged by Bors] - refactor: remove explicit legacy ports from command step (vf-000)

### DIFF
--- a/packages/base-types/src/node/push.ts
+++ b/packages/base-types/src/node/push.ts
@@ -1,16 +1,13 @@
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseCommand, BasePort, BaseStep, NodeID, SlotMappings } from './utils';
+import { BaseCommand, BaseStep, NodeID, SlotMappings } from './utils';
 
 // called the "command block" on creator-app
 export interface StepData extends SlotMappings {
   name: string;
   intent: Nullable<string>;
   diagramID: Nullable<string>;
-
-  // manually define ports to allow command step processing
-  ports: BasePort[];
 }
 
 export interface Step<Data = StepData> extends BaseStep<Data> {


### PR DESCRIPTION
### Brief description. What is this change?

This legacy `ports` structure isn't actually used anywhere anymore (and commands don't have ports 🤷)
I've tested this locally with `general-service` and `general-runtime` and they both appear to work well still

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
