### PR TITLE
perf: image step (VF-3384)

### DIFF
--- a/packages/alexa-types/src/node/display.ts
+++ b/packages/alexa-types/src/node/display.ts
@@ -14,7 +14,6 @@ export enum FrameType {
 }
 
 export interface StepData {
-  type: APLType;
   title?: string;
   aplType: APLType;
   imageURL?: string;

--- a/packages/alexa-types/src/node/display.ts
+++ b/packages/alexa-types/src/node/display.ts
@@ -2,10 +2,27 @@ import { BaseNode } from '@voiceflow/base-types';
 
 import { NodeType } from './constants';
 
-export interface StepData extends Omit<BaseNode.Visual.APLStepData, 'visualType' | 'aplType'> {
-  type: BaseNode.Visual.APLType;
+export enum APLType {
+  JSON = 'JSON',
+  SPLASH = 'SPLASH',
 }
 
+export enum FrameType {
+  AUTO = 'AUTO',
+  DEVICE = 'DEVICE',
+  CUSTOM_SIZE = 'CUSTOM_SIZE',
+}
+
+export interface StepData {
+  type: APLType;
+  title?: string;
+  aplType: APLType;
+  imageURL?: string;
+  document?: string;
+  datasource?: string;
+  aplCommands?: string;
+  jsonFileName?: string;
+}
 export interface Step extends BaseNode.Utils.BaseStep<StepData> {
   type: NodeType.DISPLAY;
 }

--- a/packages/base-types/src/node/visual.ts
+++ b/packages/base-types/src/node/visual.ts
@@ -87,7 +87,7 @@ export interface Step<Data = StepData> extends BaseStep<Data> {
 
 export interface Node extends BaseNode, NodeNextID {
   type: NodeType.VISUAL;
-  data: StepData;
+  data: ImageStepData;
 }
 
 export interface TraceFrame extends BaseTraceFrame<StepData> {

--- a/packages/base-types/src/node/visual.ts
+++ b/packages/base-types/src/node/visual.ts
@@ -34,29 +34,13 @@ export enum CanvasVisibility {
   CROPPED = 'cropped',
 }
 
-export enum APLType {
-  JSON = 'JSON',
-  SPLASH = 'SPLASH',
-}
-
-export enum VisualType {
-  APL = 'apl',
-  IMAGE = 'image',
-}
-
 export enum FrameType {
   AUTO = 'AUTO',
   DEVICE = 'DEVICE',
   CUSTOM_SIZE = 'CUSTOM_SIZE',
 }
 
-interface BaseStepData {
-  visualType: VisualType;
-}
-
-export interface ImageStepData extends BaseStepData {
-  visualType: VisualType.IMAGE;
-
+export interface StepData {
   image: Nullable<string>;
   device: Nullable<DeviceType>;
   frameType?: FrameType;
@@ -66,28 +50,13 @@ export interface ImageStepData extends BaseStepData {
     loop: boolean;
   };
 }
-
-export interface APLStepData extends BaseStepData {
-  visualType: VisualType.APL;
-
-  title?: string;
-  aplType: APLType;
-  imageURL?: string;
-  document?: string;
-  datasource?: string;
-  aplCommands?: string;
-  jsonFileName?: string;
-}
-
-export type StepData = ImageStepData | APLStepData;
-
 export interface Step<Data = StepData> extends BaseStep<Data> {
   type: NodeType.VISUAL;
 }
 
 export interface Node extends BaseNode, NodeNextID {
   type: NodeType.VISUAL;
-  data: ImageStepData;
+  data: StepData;
 }
 
 export interface TraceFrame extends BaseTraceFrame<StepData> {

--- a/packages/google-dfes-types/src/node/visual.ts
+++ b/packages/google-dfes-types/src/node/visual.ts
@@ -1,7 +1,7 @@
 import { BaseNode } from '@voiceflow/base-types';
 
-export interface Step extends BaseNode.Visual.Step<BaseNode.Visual.ImageStepData> {}
+export interface Step extends BaseNode.Visual.Step<BaseNode.Visual.StepData> {}
 
 export interface Node extends BaseNode.Visual.Node {
-  data: BaseNode.Visual.ImageStepData;
+  data: BaseNode.Visual.StepData;
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3384**

### Brief description. What is this change?
this is going to be a breaking change. APL is a special Alexa type of display - visuals steps are general-purpose "show an image" thing.

The actual Visual *NODE* that `general-runtime` consumes should only ever be just the standard image thing, never APL.
APL should be a different step really.

I moved all the APL stuff to the display step. Visual is just Visual now