### PR TITLE
[Merged by Bors] - feat(nestjs-rate-limit): create `@voiceflow/nestjs-rate-limit` package (VF-2947)

### DIFF
--- a/packages/nestjs-rate-limit/.depcheckrc
+++ b/packages/nestjs-rate-limit/.depcheckrc
@@ -10,7 +10,7 @@
     "ttypescript"
   ],
   "ignores": [
-    "@nestjs-metrics/*",
+    "@nestjs-rate-limit/*",
     "@commitlint/*",
     "@types/*",
     "@voiceflow/commitlint-config",

--- a/packages/nestjs-rate-limit/.depcheckrc
+++ b/packages/nestjs-rate-limit/.depcheckrc
@@ -1,0 +1,23 @@
+{
+  "specials": [
+    "bin",
+    "eslint",
+    "lint-staged",
+    "istanbul",
+    "commitizen",
+    "husky",
+    "prettier",
+    "ttypescript"
+  ],
+  "ignores": [
+    "@nestjs-metrics/*",
+    "@commitlint/*",
+    "@types/*",
+    "@voiceflow/commitlint-config",
+    "@voiceflow/git-branch-check",
+    "fixpack",
+    "husky",
+    "lint-staged",
+    "eslint-import-resolver-typescript"
+  ]
+}

--- a/packages/nestjs-rate-limit/.eslintignore
+++ b/packages/nestjs-rate-limit/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+build
+nyc_*
+.nyc_*

--- a/packages/nestjs-rate-limit/.eslintrc.js
+++ b/packages/nestjs-rate-limit/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: {
+    'no-underscore-dangle': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    'class-methods-use-this': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: true,
+      },
+    ],
+  },
+};

--- a/packages/nestjs-rate-limit/.nycrc.json
+++ b/packages/nestjs-rate-limit/.nycrc.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "include": [
+    "src/**"
+  ],
+  "reporter": [
+    "html",
+    "text",
+    "text-summary",
+    "lcov"
+  ],
+  "report-dir": "nyc_coverage",
+  "extension": [
+    ".ts"
+  ]
+}

--- a/packages/nestjs-rate-limit/CHANGELOG.md
+++ b/packages/nestjs-rate-limit/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [1.1.1](https://github.com/voiceflow/libs/compare/@voiceflow/nestjs-metrics@1.1.0...@voiceflow/nestjs-metrics@1.1.1) (2022-03-24)
+
+
+### Bug Fixes
+
+* **nestjs-metrics:** export everything (VF-000) ([#229](https://github.com/voiceflow/libs/issues/229)) ([f6542b6](https://github.com/voiceflow/libs/commit/f6542b665345ef6958f2b7f942e510662b775065))
+
+
+
+
+
+# 1.1.0 (2022-03-18)
+
+
+### Features
+
+* **nestjs-metrics:** create `@voiceflow/nestjs-metrics` package (VF-2949) ([#227](https://github.com/voiceflow/libs/issues/227)) ([ffaf8f0](https://github.com/voiceflow/libs/commit/ffaf8f0ba949d71727661c7eff4aa65d35fb068b))

--- a/packages/nestjs-rate-limit/CHANGELOG.md
+++ b/packages/nestjs-rate-limit/CHANGELOG.md
@@ -2,21 +2,3 @@
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [1.1.1](https://github.com/voiceflow/libs/compare/@voiceflow/nestjs-metrics@1.1.0...@voiceflow/nestjs-metrics@1.1.1) (2022-03-24)
-
-
-### Bug Fixes
-
-* **nestjs-metrics:** export everything (VF-000) ([#229](https://github.com/voiceflow/libs/issues/229)) ([f6542b6](https://github.com/voiceflow/libs/commit/f6542b665345ef6958f2b7f942e510662b775065))
-
-
-
-
-
-# 1.1.0 (2022-03-18)
-
-
-### Features
-
-* **nestjs-metrics:** create `@voiceflow/nestjs-metrics` package (VF-2949) ([#227](https://github.com/voiceflow/libs/issues/227)) ([ffaf8f0](https://github.com/voiceflow/libs/commit/ffaf8f0ba949d71727661c7eff4aa65d35fb068b))

--- a/packages/nestjs-rate-limit/README.md
+++ b/packages/nestjs-rate-limit/README.md
@@ -1,0 +1,9 @@
+# NestJS Metrics
+
+Record NestJS application metrics with OpenTelemetry.
+
+## Installation
+
+```sh
+yarn add @voiceflow/nestjs-metrics
+```

--- a/packages/nestjs-rate-limit/README.md
+++ b/packages/nestjs-rate-limit/README.md
@@ -1,9 +1,74 @@
-# NestJS Metrics
+# NestJS Rate Limit
 
-Record NestJS application metrics with OpenTelemetry.
+HTTP request rate limiting for NestJS.
 
 ## Installation
 
 ```sh
-yarn add @voiceflow/nestjs-metrics
+yarn add @voiceflow/nestjs-rate-limit
+```
+
+This package also requires you to have `@voiceflow/nestjs-rate-limit` installed.
+
+## Usage
+
+### Module registration
+
+The redis module can be setup in a couple different ways using `forRootAsync`:
+
+- A `RateLimitOptions` object can be provided via `useValue`.
+- A `useFactory` function can be provided to return a `RateLimitOptions` object (or a promise for one!).
+- A class implementing `RateLimitOptions` can be provided using `useClass`.
+
+```ts
+import { RateLimitModule, RateLimitService, RateLimitOptions } from '@voiceflow/nestjs-rate-limit';
+
+@Module({
+  imports: [
+    RateLimitModule.forRootAsync({
+      imports: [],
+
+      // Union field, one of `useValue`, `useFactory`, or `useClass`:
+      useValue: {
+        serviceName: 'my-service',
+        points: 5,
+        duration: 60,
+      },
+      useFactory: () => getRateLimitConfig(),
+      useClass: RateLimitConfigService,
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+If you have an existing rate limit options object that you'd like to reuse, you can provide that in `forRoot`.
+
+```ts
+const rateLimitOptions = { ... };
+
+@Module({
+  imports: [
+    RateLimitModule.forRoot(rateLimitOptions),
+  ],
+})
+export class AppModule {}
+```
+
+Once the `RateLimitModule` is globally registered, `RateLimitService` can be injected in other providers without having to import `RateLimitModule` again.
+
+### `RateLimitGuard`
+
+By default no routes will be rate limited.
+To apply rate limiting to a route or controller use `RateLimitGuard`:
+
+```ts
+import { Controller, UseGuards } from '@nestjs/common';
+import { RateLimitGuard } from '@voiceflow/nestjs-rate-limit';
+
+@Controller()
+@UseGuards(RateLimitGuard)
+export class MyController {
+  /* ... */
+}
 ```

--- a/packages/nestjs-rate-limit/README.md
+++ b/packages/nestjs-rate-limit/README.md
@@ -8,7 +8,7 @@ HTTP request rate limiting for NestJS.
 yarn add @voiceflow/nestjs-rate-limit
 ```
 
-This package also requires you to have `@voiceflow/nestjs-rate-limit` installed.
+This package also requires you to have `@voiceflow/nestjs-redis` installed since `RateLimitModule` uses `RedisModule` as a dependency.
 
 ## Usage
 

--- a/packages/nestjs-rate-limit/README.md
+++ b/packages/nestjs-rate-limit/README.md
@@ -72,3 +72,9 @@ export class MyController {
   /* ... */
 }
 ```
+
+#### Default token extractor
+
+The default token extractor will extract the user's token from the request headers or cookies.
+
+For using cookies you must install `cookie-parser` and configure it per [the NestJS documentation](https://docs.nestjs.com/techniques/cookies#use-with-express-default).

--- a/packages/nestjs-rate-limit/config/tests/mocharc.yml
+++ b/packages/nestjs-rate-limit/config/tests/mocharc.yml
@@ -1,0 +1,18 @@
+require:
+  - source-map-support/register
+
+timeout: 4000
+exit: true
+recursive: true
+
+watchFiles:
+  - test/**/*
+  - src/**/*
+watchExtensions:
+  - js
+  - jsx
+  - ts
+  - tsx
+
+spec:
+  - tests/setup.ts

--- a/packages/nestjs-rate-limit/package.json
+++ b/packages/nestjs-rate-limit/package.json
@@ -51,7 +51,8 @@
   "peerDependencies": {
     "@nestjs/common": "^8.4.1",
     "@types/express": "^4.17.13",
-    "@voiceflow/nestjs-redis": "^1.1.1"
+    "@voiceflow/nestjs-redis": "^1.1.1",
+    "express": "^4.18.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nestjs-rate-limit/package.json
+++ b/packages/nestjs-rate-limit/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@voiceflow/nestjs-rate-limit",
+  "description": "HTTP request rate-limiting for NestJS.",
+  "version": "1.0.0",
+  "author": "Voiceflow",
+  "bugs": {
+    "url": "https://github.com/voiceflow/libs/issues"
+  },
+  "dependencies": {
+    "rate-limiter-flexible": "2.3.6"
+  },
+  "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@nestjs/common": "^8.4.1",
+    "@types/chai": "4.3.0",
+    "@types/chai-as-promised": "^7.1.4",
+    "@types/express": "^4.17.13",
+    "@types/mocha": "^8.2.2",
+    "@types/node": "16.11.12",
+    "@voiceflow/nestjs-redis": "1.1.1",
+    "@zerollup/ts-transform-paths": "^1.7.18",
+    "chai": "4.3.6",
+    "chai-as-promised": "^7.1.1",
+    "depcheck": "^1.4.1",
+    "lint-staged": "^11.0.0",
+    "mocha": "9.1.3",
+    "nyc": "^15.1.0",
+    "rimraf": "^3.0.2",
+    "ts-mocha": "^8.0.0",
+    "ts-node": "10.5.0",
+    "tsconfig-paths": "3.12.0",
+    "ttypescript": "1.5.13",
+    "typescript": "4.6.2"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "files": [
+    "build/"
+  ],
+  "homepage": "https://github.com/voiceflow/libs#readme",
+  "keywords": [
+    "rate-limit",
+    "nestjs",
+    "rate",
+    "limit",
+    "http"
+  ],
+  "license": "ISC",
+  "main": "build/index.js",
+  "peerDependencies": {
+    "@nestjs/common": "^8.4.1",
+    "@types/express": "^4.17.13",
+    "@voiceflow/nestjs-redis": "^1.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voiceflow/libs.git"
+  },
+  "scripts": {
+    "build": "ttsc --project ./tsconfig.build.json",
+    "clean": "rimraf build",
+    "commit": "cz",
+    "lint": "eslint \"**/*.{js,ts}\"",
+    "lint:fix": "yarn lint --fix",
+    "lint:quiet": "yarn lint --quiet",
+    "lint:report": "eslint-output --quiet \"**/*.{js,ts}\"",
+    "prebuild": "yarn clean",
+    "tdd": "yarn test --watch",
+    "test": "yarn test:run",
+    "test:dependencies": "depcheck",
+    "test:integration": "NODE_ENV=test nyc --report-dir nyc_coverage_integration ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.it.ts'",
+    "test:run": "NODE_ENV=test nyc ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.{unit,it}.ts'",
+    "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
+    "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
+  },
+  "types": "build/index.d.ts"
+}

--- a/packages/nestjs-rate-limit/package.json
+++ b/packages/nestjs-rate-limit/package.json
@@ -52,6 +52,7 @@
     "@nestjs/common": "^8.4.1",
     "@types/express": "^4.17.13",
     "@voiceflow/nestjs-redis": "^1.1.1",
+    "cookie-parser": "^1.4.6",
     "express": "^4.18.1"
   },
   "publishConfig": {

--- a/packages/nestjs-rate-limit/sonar-project.properties
+++ b/packages/nestjs-rate-limit/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectName=libs-nestjs-rate-limit
+sonar.sources=src
+sonar.tests=tests
+sonar.eslint.reportPaths=sonar/report.json
+sonar.typescript.tsconfigPath=./tsconfig.json
+sonar.javascript.lcov.reportPaths=nyc_coverage_unit/lcov.info,nyc_coverage_integration/lcov.info

--- a/packages/nestjs-rate-limit/src/constants.ts
+++ b/packages/nestjs-rate-limit/src/constants.ts
@@ -1,0 +1,3 @@
+export const Providers = {
+  RATE_LIMIT_OPTIONS: Symbol('@voiceflow/nestjs-rate-limit RateLimitOptions'),
+} as const;

--- a/packages/nestjs-rate-limit/src/index.ts
+++ b/packages/nestjs-rate-limit/src/index.ts
@@ -1,0 +1,6 @@
+export { Providers } from './constants';
+export { RateLimitModuleAsyncOptions, RateLimitOptions } from './interfaces/rate-limit-options.interface';
+export { TokenExtractor } from './interfaces/token-extractor.interface';
+export { RateLimitGuard } from './rate-limit.guard';
+export { RateLimitModule } from './rate-limit.module';
+export { RateLimitService } from './rate-limit.service';

--- a/packages/nestjs-rate-limit/src/interfaces/ok.interface.ts
+++ b/packages/nestjs-rate-limit/src/interfaces/ok.interface.ts
@@ -1,0 +1,12 @@
+import { Result } from './result.interface';
+
+/**
+ * The result of successfully consuming a request without exceeding the rate-limit.
+ */
+export interface Ok extends Result {
+  kind: 'ok';
+
+  limit: number;
+  limitRemaining: number;
+  resetsAt: Date;
+}

--- a/packages/nestjs-rate-limit/src/interfaces/rate-limit-options.interface.ts
+++ b/packages/nestjs-rate-limit/src/interfaces/rate-limit-options.interface.ts
@@ -1,0 +1,21 @@
+import { ModuleMetadata, Type } from '@nestjs/common';
+
+import { TokenExtractor } from './token-extractor.interface';
+
+export interface RateLimitOptions {
+  /** The name of the service. */
+  readonly serviceName: string;
+  readonly points: number;
+  readonly duration: number;
+  /**
+   * The user auth token extractor to use on HTTP requests.
+   * Defaults to reading from headers or cookies.
+   */
+  readonly tokenExtractor?: TokenExtractor;
+}
+
+export interface RateLimitModuleAsyncOptions extends Pick<ModuleMetadata, 'providers' | 'imports'> {
+  useClass?: Type<RateLimitOptions>;
+  useFactory?: (...args: any[]) => PromiseLike<RateLimitOptions> | RateLimitOptions;
+  inject?: any[];
+}

--- a/packages/nestjs-rate-limit/src/interfaces/result.interface.ts
+++ b/packages/nestjs-rate-limit/src/interfaces/result.interface.ts
@@ -1,0 +1,3 @@
+export interface Result {
+  kind: 'ok' | 'too-many-requests';
+}

--- a/packages/nestjs-rate-limit/src/interfaces/token-extractor.interface.ts
+++ b/packages/nestjs-rate-limit/src/interfaces/token-extractor.interface.ts
@@ -1,0 +1,7 @@
+import { ExecutionContext } from '@nestjs/common';
+
+/**
+ * Extracts user auth tokens from requests
+ * @returns The user token, if it could be extracted
+ */
+export type TokenExtractor = (executionContext: ExecutionContext) => string | undefined;

--- a/packages/nestjs-rate-limit/src/interfaces/too-many-requests.interface.ts
+++ b/packages/nestjs-rate-limit/src/interfaces/too-many-requests.interface.ts
@@ -1,0 +1,9 @@
+import { Result } from './result.interface';
+
+/** The result of a user trying to consume too many requests and being rate-limited. */
+export interface TooManyRequests extends Result {
+  kind: 'too-many-requests';
+
+  /** The number of seconds an API consumer should wait before sending another request. */
+  retryAfterSeconds: number;
+}

--- a/packages/nestjs-rate-limit/src/rate-limit.guard.ts
+++ b/packages/nestjs-rate-limit/src/rate-limit.guard.ts
@@ -12,7 +12,6 @@ export class RateLimitGuard implements CanActivate {
   private static extractTokenFromHeadersOrCookies(executionContext: ExecutionContext): string | undefined {
     const request = executionContext.switchToHttp().getRequest<Request>();
 
-    // TODO: Pretty sure this is not how we're meant to access the cookies
     return request.headers.authorization || request.cookies.auth_vf;
   }
 

--- a/packages/nestjs-rate-limit/src/rate-limit.guard.ts
+++ b/packages/nestjs-rate-limit/src/rate-limit.guard.ts
@@ -1,0 +1,45 @@
+import { CanActivate, ExecutionContext, HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import assert from 'assert/strict';
+import { Request, Response } from 'express';
+
+import { Providers } from './constants';
+import { RateLimitOptions } from './interfaces/rate-limit-options.interface';
+import { TokenExtractor } from './interfaces/token-extractor.interface';
+import { RateLimitService } from './rate-limit.service';
+
+@Injectable()
+export class RateLimitGuard implements CanActivate {
+  private static extractTokenFromHeadersOrCookies(executionContext: ExecutionContext): string | undefined {
+    const request = executionContext.switchToHttp().getRequest<Request>();
+
+    // TODO: Pretty sure this is not how we're meant to access the cookies
+    return request.headers.authorization || request.cookies.auth_vf;
+  }
+
+  private readonly tokenExtractor: TokenExtractor;
+
+  constructor(private readonly service: RateLimitService, @Inject(Providers.RATE_LIMIT_OPTIONS) options: RateLimitOptions) {
+    this.tokenExtractor = options.tokenExtractor || RateLimitGuard.extractTokenFromHeadersOrCookies;
+  }
+
+  async canActivate(context: ExecutionContext): Promise<true> {
+    const httpContext = context.switchToHttp();
+    const response = httpContext.getResponse<Response<never>>();
+
+    const token = this.tokenExtractor(context);
+    assert(token, 'Expected request token to be defined, you must run the auth guard before this one');
+
+    const result = await this.service.consume(token);
+
+    if (result.kind === 'ok') {
+      response.setHeader('X-RateLimit-Limit', result.limit);
+      response.setHeader('X-RateLimit-Remaining', result.limitRemaining);
+      response.setHeader('X-RateLimit-Reset', result.resetsAt.toString());
+
+      return true;
+    }
+
+    response.setHeader('Retry-After', result.retryAfterSeconds);
+    throw new HttpException('You have sent too many requests and are being ratelimited', HttpStatus.TOO_MANY_REQUESTS);
+  }
+}

--- a/packages/nestjs-rate-limit/src/rate-limit.module.ts
+++ b/packages/nestjs-rate-limit/src/rate-limit.module.ts
@@ -1,0 +1,60 @@
+import { DynamicModule, Module } from '@nestjs/common';
+
+import { Providers } from './constants';
+import { RateLimitModuleAsyncOptions, RateLimitOptions } from './interfaces/rate-limit-options.interface';
+import { RateLimitGuard } from './rate-limit.guard';
+import { RateLimitService } from './rate-limit.service';
+
+@Module({})
+export class RateLimitModule {
+  static forRoot(options: RateLimitOptions): DynamicModule {
+    return {
+      global: true,
+      module: RateLimitModule,
+      providers: [{ provide: Providers.RATE_LIMIT_OPTIONS, useValue: options }, RateLimitService, RateLimitGuard],
+      exports: [RateLimitService, Providers.RATE_LIMIT_OPTIONS, RateLimitGuard],
+    };
+  }
+
+  static forRootAsync(options: RateLimitModuleAsyncOptions): DynamicModule {
+    if (options.useFactory) {
+      return {
+        global: true,
+        module: RateLimitModule,
+        imports: options.imports,
+        providers: [
+          {
+            provide: Providers.RATE_LIMIT_OPTIONS,
+            useFactory: options.useFactory,
+            inject: options.inject ?? [],
+          },
+          RateLimitService,
+          RateLimitGuard,
+          ...(options.providers ?? []),
+        ],
+        exports: [RateLimitService, Providers.RATE_LIMIT_OPTIONS, RateLimitGuard],
+      };
+    }
+
+    if (options.useClass) {
+      return {
+        global: true,
+        module: RateLimitModule,
+        imports: options.imports,
+        providers: [
+          {
+            provide: Providers.RATE_LIMIT_OPTIONS,
+            useClass: options.useClass,
+            inject: options.inject ?? [],
+          },
+          RateLimitService,
+          RateLimitGuard,
+          ...(options.providers ?? []),
+        ],
+        exports: [RateLimitService, Providers.RATE_LIMIT_OPTIONS, RateLimitGuard],
+      };
+    }
+
+    throw new RangeError('Expected a useExisting, useFactory, or useClass value to be present in the options');
+  }
+}

--- a/packages/nestjs-rate-limit/src/rate-limit.service.ts
+++ b/packages/nestjs-rate-limit/src/rate-limit.service.ts
@@ -1,0 +1,52 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { RedisConnection, RedisService } from '@voiceflow/nestjs-redis';
+import { RateLimiterRedis, RateLimiterRes, RateLimiterStoreAbstract } from 'rate-limiter-flexible';
+
+import { Providers } from './constants';
+import { Ok } from './interfaces/ok.interface';
+import { RateLimitOptions } from './interfaces/rate-limit-options.interface';
+import { TooManyRequests } from './interfaces/too-many-requests.interface';
+
+@Injectable()
+export class RateLimitService {
+  private readonly rateLimiter: RateLimiterStoreAbstract;
+
+  constructor(@Inject(Providers.RATE_LIMIT_OPTIONS) private readonly config: RateLimitOptions, redis: RedisService) {
+    const storeClient: RedisConnection = redis.connection;
+
+    this.rateLimiter = new RateLimiterRedis({
+      points: config.points,
+      duration: config.duration,
+      keyPrefix: config.serviceName,
+      storeClient,
+    });
+  }
+
+  async consume(token: string): Promise<Ok | TooManyRequests> {
+    try {
+      const successResult = await this.rateLimiter.consume(token);
+
+      const result: Ok = {
+        kind: 'ok',
+
+        limit: this.config.points,
+        limitRemaining: successResult.remainingPoints,
+        resetsAt: new Date(Date.now() + successResult.msBeforeNext),
+      };
+
+      return result;
+    } catch (error) {
+      if (error instanceof RateLimiterRes) {
+        const result: TooManyRequests = {
+          kind: 'too-many-requests',
+
+          retryAfterSeconds: Math.floor(error.msBeforeNext / 1000),
+        };
+
+        return result;
+      }
+
+      throw error;
+    }
+  }
+}

--- a/packages/nestjs-rate-limit/tests/setup.ts
+++ b/packages/nestjs-rate-limit/tests/setup.ts
@@ -1,0 +1,4 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);

--- a/packages/nestjs-rate-limit/tsconfig.build.json
+++ b/packages/nestjs-rate-limit/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "build",
+    "plugins": [
+      {
+        "transform": "@zerollup/ts-transform-paths"
+      }
+    ],
+    "traceResolution": false,
+    "skipLibCheck": true
+  },
+  "include": ["src", "typings"]
+}

--- a/packages/nestjs-rate-limit/tsconfig.json
+++ b/packages/nestjs-rate-limit/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "extends": "@voiceflow/tsconfig",
+  "compilerOptions": {
+    // General
+    "target": "es2021",
+    "module": "commonjs",
+    "lib": ["es2021"],
+    "experimentalDecorators": true,
+    "baseUrl": "./",
+    "paths": {
+      "@nestjs-metrics/*": ["src/*"]
+    },
+
+    // Strictness
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Modules
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+
+    // Emit
+    "outDir": "./build",
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "sourceMap": true
+  },
+  "include": ["src", "tests", "typings"],
+  "exclude": ["**/node_modules", "**/.*/"]
+}

--- a/packages/nestjs-rate-limit/tsconfig.json
+++ b/packages/nestjs-rate-limit/tsconfig.json
@@ -8,7 +8,7 @@
     "experimentalDecorators": true,
     "baseUrl": "./",
     "paths": {
-      "@nestjs-metrics/*": ["src/*"]
+      "@nestjs-rate-limit/*": ["src/*"]
     },
 
     // Strictness

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,6 +1574,14 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/chai-as-promised@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz#caf64e76fb056b8c8ced4b761ed499272b737601"
@@ -1593,10 +1601,36 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
   integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
 
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/crypto-js@^4.0.2":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.0.tgz#09ba1b49bcce62c9a8e6d5e50a3364aa98975578"
   integrity sha512-DCFfy/vh2lG6qHSGezQ+Sn2Ulf/1Mx51dqOdmOKyW5nMK3maLlxeS3onC7r212OnBM2pBR95HkAmAjjF08YkxQ==
+
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.28"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
+  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/ioredis@^4.28.10":
   version "4.28.10"
@@ -1626,6 +1660,11 @@
   version "4.14.178"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
   integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -1671,6 +1710,24 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/serve-static@*":
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
+  integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@types/sinon@^10.0.0":
   version "10.0.10"
@@ -2050,6 +2107,21 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
     type-fest "^0.21.3"
+
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -6933,6 +7005,11 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+rate-limiter-flexible@2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-2.3.6.tgz#b1a2549dca91069c8a33d57c08a27262c0356c60"
+  integrity sha512-8DVFOe89rreyut/vzwBI7vgXJynyYoYnH5XogtAKs0F/neAbCTTglXxSJ7fZeZamcFXZDvMidCBvps4KM+1srw==
+
 rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -7737,7 +7814,28 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,21 +2108,6 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -7814,28 +7799,7 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,21 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -2973,6 +2988,24 @@ convert-source-map@^1.7.0:
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie-parser@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
+  integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
+  dependencies:
+    cookie "0.4.1"
+    cookie-signature "1.0.6"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 core-js-pure@^3.20.2:
   version "3.21.0"
@@ -7799,7 +7832,28 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,21 +2108,6 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -2988,24 +2973,6 @@ convert-source-map@^1.7.0:
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
-
-cookie-parser@^1.4.6:
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
-  integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
-  dependencies:
-    cookie "0.4.1"
-    cookie-signature "1.0.6"
-
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
-  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
-
-cookie@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 core-js-pure@^3.20.2:
   version "3.21.0"
@@ -7832,28 +7799,7 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
**Fixes or implements VF-2947**

### Brief description. What is this change?

adds a `@voiceflow/nestjs-rate-limit` package, extracted from `canvas-export` with a few tweaks made for more modular usage

### Related PRs

- https://github.com/voiceflow/canvas-export/pull/110

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written