### PR TITLE
[Merged by Bors] - fix(nestjs-rate-limit): safe accessing of `request.cookies` (VF-000)

### DIFF
--- a/packages/nestjs-rate-limit/src/rate-limit.guard.ts
+++ b/packages/nestjs-rate-limit/src/rate-limit.guard.ts
@@ -12,7 +12,7 @@ export class RateLimitGuard implements CanActivate {
   private static extractTokenFromHeadersOrCookies(executionContext: ExecutionContext): string | undefined {
     const request = executionContext.switchToHttp().getRequest<Request>();
 
-    return request.headers.authorization || request.cookies.auth_vf;
+    return request.headers.authorization || request.cookies?.auth_vf;
   }
 
   private readonly tokenExtractor: TokenExtractor;


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

do not assume that `request.cookies` is an object

i believe this will fix a bug that would affect users who have requests without an `authorization` header present and who don't have a cookie parser configured

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written