### PR TITLE
[Merged by Bors] - feat: update command type (VF-000)

### DIFF
--- a/packages/base-types/src/node/jump.ts
+++ b/packages/base-types/src/node/jump.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseCommand, BaseStep, NodeID, SlotMappings } from './utils';
+import { BaseCommand, BaseStep, CommandType, NodeID, SlotMappings } from './utils';
 
 export enum IntentAvailability {
   LOCAL = 'LOCAL',
@@ -23,7 +23,7 @@ export interface Step<Data = StepData> extends BaseStep<Data> {
  * use Node.Utils.AnyCommand for other platforms
  */
 export interface Command extends BaseCommand, Required<SlotMappings> {
-  type: NodeType.INTENT;
+  type: CommandType.JUMP;
   next: NodeID;
   intent: string;
   diagramID?: string;

--- a/packages/base-types/src/node/push.ts
+++ b/packages/base-types/src/node/push.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '@base-types/types';
 
 import { NodeType } from './constants';
-import { BaseCommand, BaseStep, NodeID, SlotMappings } from './utils';
+import { BaseCommand, BaseStep, CommandType, NodeID, SlotMappings } from './utils';
 
 // called the "command block" on creator-app
 export interface StepData extends SlotMappings {
@@ -19,7 +19,7 @@ export interface Step<Data = StepData> extends BaseStep<Data> {
  * use Node.Utils.AnyCommand for other platforms
  */
 export interface Command extends BaseCommand, Required<SlotMappings> {
-  type: NodeType.COMMAND;
+  type: CommandType.PUSH;
   next?: NodeID;
   intent: string;
   diagram_id?: string;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
To accompany @astopo 's migration. It turns out many legacy google and alexa projects (as mentioned in the comments) either don't have a `command[].type` or they are just `type: "intent"` or `type: "command"`.

The new format we use is either `"jump"` or `"push"` which will bring it in line with `general-runtime`. During the migration we will convert ALL command types to this new format. What is nice is the runtime doesn't care about the actual `type` property at all, it just checks for the existence of other properties, so this is non-breaking downstream.

google-runtime:
https://github.com/voiceflow/google-runtime/blob/f4cdb47be45df8c61a076e46a17e59a6d7e9d6fb/lib/services/runtime/handlers/command.ts#L12-L18

alexa-runtime:
https://github.com/voiceflow/alexa-runtime/blob/74a292aef66964b0d7a3c6161b7dd6dcfa2d3c45/lib/services/runtime/handlers/command.ts#L14-L20