### PR TITLE
[Merged by Bors] - feat: added phraselists property to LuisWorkspace (VF-3494)

### DIFF
--- a/packages/voiceflow-types/src/luis/types.ts
+++ b/packages/voiceflow-types/src/luis/types.ts
@@ -104,6 +104,14 @@ export interface LuisClosedList {
   subLists: LuisSubList[];
 }
 
+export interface LuisPhraseList {
+  name: string;
+  mode: boolean;
+  words: string;
+  activated: string;
+  enabledForAllModels: boolean;
+}
+
 export interface LuisWorkspace {
   culture: string;
   intents: LuisIntentStructure[];
@@ -111,4 +119,5 @@ export interface LuisWorkspace {
   closedLists: LuisClosedList[];
   builtInEntities: LuisBuiltInEntity[];
   utterances: LuisUtterance[];
+  phraselists: LuisPhraseList[];
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3494**

### Brief description. What is this change?

Adds a `phraselists` property to the `LUISWorkspace` type. The `phraselists` property is an array of `LuisPhraseLists` where `LuisPhraseLists.words` is a CSV-string containing entity values that can be passed into an ML model as training examples. For example, a phrase list would be:
 
```js
"apricot,apple,orange,banana,pineapple"
```

### Implementation details. How do you make this change?

Added the type to TypeScript based on the JSON file found in this [ticket](https://voiceflow.atlassian.net/browse/VF-3494) 

### Setup information

N/A

### Deployment Notes

N/A

### Related PRs

- https://github.com/voiceflow/general-service/pull/330

### Checklist

- ~~[ ] this is a breaking change and should publish a new major version~~
- ~~[ ] appropriate tests have been written~~
