### PR TITLE
[Merged by Bors] - refactor: avoid type duplication of `AnyRecord`, `EmptyObject`, `Nullable<T>`, and `Struct` (VF-000)

### DIFF
--- a/packages/alexa-types/src/node/accountLinking.ts
+++ b/packages/alexa-types/src/node/accountLinking.ts
@@ -1,8 +1,9 @@
-import { BaseNode, UnknownRecord } from '@voiceflow/base-types';
+import { BaseNode } from '@voiceflow/base-types';
+import { Struct } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 
-export type StepData = UnknownRecord;
+export type StepData = Struct;
 
 export interface Step extends BaseNode.Utils.BaseStep<StepData> {
   type: NodeType.ACCOUNT_LINKING;

--- a/packages/alexa-types/src/version/settings.ts
+++ b/packages/alexa-types/src/version/settings.ts
@@ -1,5 +1,5 @@
 import { Voice } from '@alexa-types/constants';
-import { Nullable } from '@voiceflow/base-types';
+import { Nullable } from '@voiceflow/common';
 import { VoiceVersion } from '@voiceflow/voice-types';
 import { v1 } from 'ask-smapi-model';
 

--- a/packages/api-sdk/src/resources/crud.ts
+++ b/packages/api-sdk/src/resources/crud.ts
@@ -1,5 +1,5 @@
 import type { PutPostType, SchemeType } from '@api-sdk/types';
-import type { AnyRecord } from '@voiceflow/base-types';
+import type { AnyRecord } from '@voiceflow/common';
 
 import BaseResource, { Fields } from './base';
 

--- a/packages/api-sdk/src/resources/project/index.ts
+++ b/packages/api-sdk/src/resources/project/index.ts
@@ -1,5 +1,6 @@
 import type Fetch from '@api-sdk/fetch';
-import { AnyRecord, BaseModels } from '@voiceflow/base-types';
+import { BaseModels } from '@voiceflow/base-types';
+import { AnyRecord } from '@voiceflow/common';
 
 import { Fields } from '../base';
 import CrudResource from '../crud';

--- a/packages/api-sdk/src/resources/project/member.ts
+++ b/packages/api-sdk/src/resources/project/member.ts
@@ -1,5 +1,6 @@
 import Fetch, { PathVariables } from '@api-sdk/fetch';
-import { AnyRecord, BaseModels } from '@voiceflow/base-types';
+import { BaseModels } from '@voiceflow/base-types';
+import { AnyRecord } from '@voiceflow/common';
 
 import BaseResource, { Fields } from '../base';
 import { ENDPOINT } from './constants';

--- a/packages/api-sdk/src/resources/version.ts
+++ b/packages/api-sdk/src/resources/version.ts
@@ -1,5 +1,6 @@
 import Fetch from '@api-sdk/fetch';
-import { AnyRecord, BaseModels } from '@voiceflow/base-types';
+import { BaseModels } from '@voiceflow/base-types';
+import { AnyRecord } from '@voiceflow/common';
 
 import { Fields } from './base';
 import CrudResource from './crud';

--- a/packages/api-sdk/src/types.ts
+++ b/packages/api-sdk/src/types.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@voiceflow/base-types';
+import { AnyRecord } from '@voiceflow/common';
 
 export type Flatten<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
 

--- a/packages/base-types/src/button/index.ts
+++ b/packages/base-types/src/button/index.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 export enum ButtonType {
   INTENT = 'INTENT',

--- a/packages/base-types/src/models/apiKey.ts
+++ b/packages/base-types/src/models/apiKey.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 export const API_KEY_PREFIX = 'VF.';
 

--- a/packages/base-types/src/models/base/command.ts
+++ b/packages/base-types/src/models/base/command.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 import { Variable } from './common';
 

--- a/packages/base-types/src/models/base/node.ts
+++ b/packages/base-types/src/models/base/node.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 import { AnyBaseStepPorts, BasePortList, NextStepPorts } from './port';
 

--- a/packages/base-types/src/models/base/note.ts
+++ b/packages/base-types/src/models/base/note.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 export enum NoteType {
   INTENT = 'INTENT',

--- a/packages/base-types/src/models/base/port.ts
+++ b/packages/base-types/src/models/base/port.ts
@@ -1,4 +1,4 @@
-import { EmptyRecord, Nullable } from '@base-types/types';
+import { EmptyObject, Nullable } from '@voiceflow/common';
 
 export enum PortType {
   FAIL = 'fail',
@@ -42,13 +42,13 @@ export interface BuiltInNextFailPorts extends BuiltInNextPort, BuiltInFailPort {
 
 export interface BuiltInNoMatchNoReplyPorts extends BuiltInNoMatchPort, BuiltInNoReplyPort {}
 
-export interface EmptyStepPorts extends BaseStepPorts<EmptyRecord, []> {}
+export interface EmptyStepPorts extends BaseStepPorts<EmptyObject, []> {}
 
 export interface NextStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<BuiltInNextPort, Dynamic> {}
 
 export interface SuccessFailStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<BuiltInNextFailPorts, Dynamic> {}
 
-export interface DynamicOnlyStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<EmptyRecord, Dynamic> {}
+export interface DynamicOnlyStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<EmptyObject, Dynamic> {}
 
 export interface NoMatchNoReplyStepPorts<Dynamic extends BasePort[] = BasePort[]> extends BaseStepPorts<BuiltInNoMatchNoReplyPorts, Dynamic> {}
 

--- a/packages/base-types/src/models/base/slot.ts
+++ b/packages/base-types/src/models/base/slot.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { Variable } from './common';
 

--- a/packages/base-types/src/models/project/index.ts
+++ b/packages/base-types/src/models/project/index.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 import { Member } from './member';
 import { Prototype } from './prototype';

--- a/packages/base-types/src/models/project/member.ts
+++ b/packages/base-types/src/models/project/member.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 export interface Member<P extends AnyRecord = AnyRecord> {
   creatorID: number;

--- a/packages/base-types/src/models/project/prototype.ts
+++ b/packages/base-types/src/models/project/prototype.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 import { ProjectNLP, PrototypeModel } from '../base';
 

--- a/packages/base-types/src/models/version/index.ts
+++ b/packages/base-types/src/models/version/index.ts
@@ -1,4 +1,4 @@
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 import { BaseCommand, BaseNote, Intent, Slot, Variable } from '../base';
 import { Prototype } from './prototype';

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -1,4 +1,4 @@
-import { AnyRecord, Nullable } from '@base-types/types';
+import { AnyRecord, Nullable } from '@voiceflow/common';
 
 import { BaseCommand, PrototypeModel } from '../base';
 

--- a/packages/base-types/src/node/_v1.ts
+++ b/packages/base-types/src/node/_v1.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { BaseEvent, BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeID } from './utils';
 

--- a/packages/base-types/src/node/api.ts
+++ b/packages/base-types/src/node/api.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseStep, IntegrationType, NodeSuccessFailID, SuccessFailStepPorts } from './utils';

--- a/packages/base-types/src/node/buttons.ts
+++ b/packages/base-types/src/node/buttons.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { StepButtonsLayout } from '../button';
 import { NodeType } from './constants';

--- a/packages/base-types/src/node/capture.ts
+++ b/packages/base-types/src/node/capture.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import {

--- a/packages/base-types/src/node/captureV2.ts
+++ b/packages/base-types/src/node/captureV2.ts
@@ -1,5 +1,5 @@
 import { Intent } from '@base-types/models';
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import {

--- a/packages/base-types/src/node/cardV2.ts
+++ b/packages/base-types/src/node/cardV2.ts
@@ -1,5 +1,5 @@
 import { SlateTextValue } from '@base-types/text';
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import {

--- a/packages/base-types/src/node/exit.ts
+++ b/packages/base-types/src/node/exit.ts
@@ -1,9 +1,9 @@
-import { UnknownRecord } from '@base-types/types';
+import { Struct } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, EmptyStepPorts, TraceType } from './utils';
 
-export type StepData = UnknownRecord;
+export type StepData = Struct;
 
 export interface NodeData {
   end: true;

--- a/packages/base-types/src/node/flow.ts
+++ b/packages/base-types/src/node/flow.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID, NodeVariablesMappings, TraceType } from './utils';

--- a/packages/base-types/src/node/general.ts
+++ b/packages/base-types/src/node/general.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID } from './utils';

--- a/packages/base-types/src/node/goTo.ts
+++ b/packages/base-types/src/node/goTo.ts
@@ -1,5 +1,5 @@
 import { IntentRequest } from '@base-types/request';
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseNoMatchNodeData, BaseStep } from './utils';

--- a/packages/base-types/src/node/goToBlock.ts
+++ b/packages/base-types/src/node/goToBlock.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, NodeNextID } from './utils';

--- a/packages/base-types/src/node/googleSheets.ts
+++ b/packages/base-types/src/node/googleSheets.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseStep, IntegrationType, IntegrationUser, NodeSuccessFailID, SuccessFailStepPorts } from './utils';

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -1,5 +1,5 @@
 import { AnyRequestButton } from '@base-types/request';
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import {

--- a/packages/base-types/src/node/jump.ts
+++ b/packages/base-types/src/node/jump.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseCommand, BaseStep, CommandType, NodeID, SlotMappings } from './utils';

--- a/packages/base-types/src/node/push.ts
+++ b/packages/base-types/src/node/push.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseCommand, BaseStep, CommandType, NodeID, SlotMappings } from './utils';

--- a/packages/base-types/src/node/set.ts
+++ b/packages/base-types/src/node/set.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, Expression, NodeNextID } from './utils';

--- a/packages/base-types/src/node/setV2.ts
+++ b/packages/base-types/src/node/setV2.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, ExpressionTypeV2, NodeNextID } from './utils';

--- a/packages/base-types/src/node/speak.ts
+++ b/packages/base-types/src/node/speak.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID, StepCanvasNodeVisibility, TraceType } from './utils';

--- a/packages/base-types/src/node/utils/base.ts
+++ b/packages/base-types/src/node/utils/base.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 export {
   BaseCommand,

--- a/packages/base-types/src/node/utils/command.ts
+++ b/packages/base-types/src/node/utils/command.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { BaseCommand } from './base';
 import { BaseEvent } from './event';

--- a/packages/base-types/src/node/utils/expression.ts
+++ b/packages/base-types/src/node/utils/expression.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 export enum ExpressionType {
   EQUALS = 'equals',

--- a/packages/base-types/src/node/utils/integration.ts
+++ b/packages/base-types/src/node/utils/integration.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 export enum IntegrationType {
   ZAPIER = 'Zapier',

--- a/packages/base-types/src/node/utils/noMatch.ts
+++ b/packages/base-types/src/node/utils/noMatch.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeID } from './base';
 

--- a/packages/base-types/src/node/utils/noReply.ts
+++ b/packages/base-types/src/node/utils/noReply.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeID } from './base';
 

--- a/packages/base-types/src/node/visual.ts
+++ b/packages/base-types/src/node/visual.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID, TraceType } from './utils';

--- a/packages/base-types/src/project/index.ts
+++ b/packages/base-types/src/project/index.ts
@@ -1,5 +1,5 @@
 import { Project as ProjectModels } from '@base-types/models';
-import { AnyRecord } from '@base-types/types';
+import { AnyRecord } from '@voiceflow/common';
 
 export interface PlatformData extends AnyRecord {}
 

--- a/packages/base-types/src/types.ts
+++ b/packages/base-types/src/types.ts
@@ -1,10 +1,13 @@
-export type Nullable<T> = T | null;
-
-export type AnyRecord = Record<string, any>;
-
-export type UnknownRecord = Record<string, unknown>;
-
-export type EmptyRecord = Record<string, never>;
+export {
+  /** @deprecated Use `AnyRecord` from `@voiceflow/common`. */
+  AnyRecord,
+  /** @deprecated Use `EmptyObject` from `@voiceflow/common`. */
+  EmptyObject as EmptyRecord,
+  /** @deprecated Use `Nullable` from `@voiceflow/common`. */
+  Nullable,
+  /** @deprecated Use `Struct` from `@voiceflow/common`. */
+  Struct as UnknownRecord,
+} from '@voiceflow/common';
 
 export type DeepPartialByKey<T, K extends keyof T> = {
   [P in keyof T]?: P extends K ? Partial<T[P]> : T[P];

--- a/packages/base-types/src/version/settings.ts
+++ b/packages/base-types/src/version/settings.ts
@@ -1,5 +1,5 @@
 import { CardLayout } from '@base-types/node/cardV2';
-import { Nullable } from '@base-types/types';
+import { Nullable } from '@voiceflow/common';
 
 import { Utils } from '../node';
 

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.25.2"
+    "@voiceflow/base-types": "^2.25.2",
+    "@voiceflow/common": "7.26.1"
   },
   "files": [
     "build"

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@voiceflow/base-types": "^2.25.2",
-    "@voiceflow/common": "7.26.1"
+    "@voiceflow/common": "^7.26.1"
   },
   "files": [
     "build"

--- a/packages/chat-types/src/utils/prompt.ts
+++ b/packages/chat-types/src/utils/prompt.ts
@@ -1,5 +1,5 @@
 import { Prompt } from '@chat-types/models';
-import { Nullable } from '@voiceflow/base-types';
+import { Nullable } from '@voiceflow/common';
 
 export const defaultPrompt = (prompt: Nullable<Prompt> | undefined): Nullable<Prompt> => {
   if (!prompt?.content) {

--- a/packages/google-dfes-types/src/project/base.ts
+++ b/packages/google-dfes-types/src/project/base.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@voiceflow/base-types';
+import { Nullable } from '@voiceflow/common';
 
 export interface BaseMemberPlatformData {
   agentName: Nullable<string>;

--- a/packages/google-types/src/project/base.ts
+++ b/packages/google-types/src/project/base.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@voiceflow/base-types';
+import { Nullable } from '@voiceflow/common';
 
 // shared across google and dfes types
 export interface SharedBaseMemberPlatformData {

--- a/packages/voice-types/package.json
+++ b/packages/voice-types/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/voiceflow/libs/issues"
   },
   "dependencies": {
-    "@voiceflow/base-types": "^2.25.2"
+    "@voiceflow/base-types": "^2.25.2",
+    "@voiceflow/common": "7.26.1"
   },
   "files": [
     "build"

--- a/packages/voice-types/package.json
+++ b/packages/voice-types/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@voiceflow/base-types": "^2.25.2",
-    "@voiceflow/common": "7.26.1"
+    "@voiceflow/common": "^7.26.1"
   },
   "files": [
     "build"

--- a/packages/voice-types/src/utils/prompt.ts
+++ b/packages/voice-types/src/utils/prompt.ts
@@ -1,5 +1,5 @@
 import { Prompt } from '@voice-types/models';
-import { Nullable } from '@voiceflow/base-types';
+import { Nullable } from '@voiceflow/common';
 
 export const defaultPrompt = <V>(prompt: Nullable<Prompt<V>> | undefined, defaultVoice: V): Nullable<Prompt<V>> => {
   if (!prompt?.content) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,21 +2108,6 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
-ansi-regex@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -7814,28 +7799,7 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,21 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
+
+ansi-regex@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -7799,7 +7814,28 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@6.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1, strip-ansi@^4.0.0, strip-ansi@^5.1.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

these types were being defined in base-types and used across the monorepo, even though they already exist in common

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written