### PR TITLE
[Merged by Bors] - feat: add runtime logging log entry types (VF-3528)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Logs
-logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/base-types/package.json
+++ b/packages/base-types/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@voiceflow/common": "^7.26.1",
-    "slate": "0.73.0",
-    "type-fest": "2.12.2"
+    "slate": "0.73.0"
   },
   "files": [
     "build"

--- a/packages/base-types/package.json
+++ b/packages/base-types/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@voiceflow/common": "^7.26.1",
     "slate": "0.73.0",
-    "type-fest": "^2.12.2"
+    "type-fest": "2.12.2"
   },
   "files": [
     "build"

--- a/packages/base-types/package.json
+++ b/packages/base-types/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@voiceflow/common": "^7.26.1",
-    "slate": "0.73.0"
+    "slate": "0.73.0",
+    "type-fest": "^2.12.2"
   },
   "files": [
     "build"

--- a/packages/base-types/src/index.ts
+++ b/packages/base-types/src/index.ts
@@ -8,6 +8,7 @@ export * as Project from './project';
 export * as BaseProject from './project';
 export * as Request from './request';
 export * as BaseRequest from './request';
+export * as RuntimeLogs from './runtimeLogs';
 export * as Text from './text';
 export * as BaseText from './text';
 export * as Trace from './trace';

--- a/packages/base-types/src/runtimeLogs/index.ts
+++ b/packages/base-types/src/runtimeLogs/index.ts
@@ -1,0 +1,1 @@
+export * from './logs';

--- a/packages/base-types/src/runtimeLogs/logs/base.ts
+++ b/packages/base-types/src/runtimeLogs/logs/base.ts
@@ -1,0 +1,24 @@
+import { EmptyObject } from '@voiceflow/common';
+
+import { GlobalLogKinds, Iso8601Timestamp, LoggingNodeType, PathReference } from '../utils';
+import { LogLevel } from '../utils/logs';
+
+/** The base log interface. This should not be used directly, use one of the subtypes instead. */
+interface BaseLog {
+  kind: string;
+  timestamp: Iso8601Timestamp;
+  message: EmptyObject;
+  level: LogLevel;
+}
+
+export interface BaseGlobalLog<Kind extends GlobalLogKinds, Message extends EmptyObject, Level extends LogLevel = LogLevel.INFO> extends BaseLog {
+  kind: `global.${Kind}`;
+  level: Level;
+  message: Message;
+}
+
+export interface BaseStepLog<Kind extends LoggingNodeType, Message extends EmptyObject, Level extends LogLevel = LogLevel.INFO> extends BaseLog {
+  kind: `step.${Kind}`;
+  level: Level;
+  message: PathReference & Message;
+}

--- a/packages/base-types/src/runtimeLogs/logs/global/conversationStart.ts
+++ b/packages/base-types/src/runtimeLogs/logs/global/conversationStart.ts
@@ -1,0 +1,11 @@
+import { GlobalLogKinds } from '@base-types/runtimeLogs/utils';
+
+import { BaseGlobalLog } from '../base';
+
+export type ConversationStartLog = BaseGlobalLog<
+  GlobalLogKinds.CONVERSATION_START,
+  {
+    versionID: string;
+    userID: string;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/index.ts
+++ b/packages/base-types/src/runtimeLogs/logs/index.ts
@@ -1,0 +1,56 @@
+import { ConversationStartLog } from './global/conversationStart';
+import { ApiStepLog } from './steps/api';
+import { ButtonsStepLog } from './steps/buttons';
+import { CaptureStepLog } from './steps/capture';
+import { CodeStepLog } from './steps/code';
+import { ConditionStepLog } from './steps/condition';
+import { CustomActionStepLog } from './steps/customAction';
+import { ExitStepLog } from './steps/exit';
+import { FlowStepLog } from './steps/flow';
+import { IntentStepLog } from './steps/intent';
+import { RandomStepLog } from './steps/random';
+import { SetStepLog } from './steps/set';
+import { SpeakStepLog } from './steps/speak';
+import { StartStepLog } from './steps/start';
+import { TextStepLog } from './steps/text';
+
+export * from './global/conversationStart';
+export {
+  ApiStepLog,
+  ButtonsStepLog,
+  CaptureStepLog,
+  CodeStepLog,
+  ConditionStepLog,
+  CustomActionStepLog,
+  ExitStepLog,
+  FlowStepLog,
+  IntentStepLog,
+  RandomStepLog,
+  SetStepLog,
+  SpeakStepLog,
+  StartStepLog,
+  TextStepLog,
+};
+
+/** All possible runtime logs for global events. */
+type GlobalLog = ConversationStartLog;
+
+/** All possible runtime logs for steps. */
+type StepLog =
+  | ApiStepLog
+  | ButtonsStepLog
+  | CaptureStepLog
+  | CodeStepLog
+  | ConditionStepLog
+  | CustomActionStepLog
+  | ExitStepLog
+  | FlowStepLog
+  | IntentStepLog
+  | RandomStepLog
+  | SetStepLog
+  | SpeakStepLog
+  | StartStepLog
+  | TextStepLog;
+
+/** All possible runtime logs. */
+export type Log = GlobalLog | StepLog;

--- a/packages/base-types/src/runtimeLogs/logs/steps/api.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/api.ts
@@ -1,0 +1,46 @@
+import { APIBodyType, APIMethod } from '@base-types/node/api';
+import { JsonArray, JsonObject, JsonValue } from 'type-fest';
+
+import { LoggingNodeType, LogLevel } from '../../utils';
+import { BaseStepLog } from '../base';
+
+interface ApiLogMessage {
+  request: {
+    method: APIMethod;
+    url: string;
+  };
+  response: {
+    statusCode: number;
+    statusMessage: string;
+  };
+}
+
+interface VerboseApiLogMessage {
+  request: {
+    headers: Record<string, string>;
+    query: Record<string, string>;
+  } & (
+    | {
+        method: Exclude<APIMethod, APIMethod.GET>;
+        bodyType: APIBodyType;
+        body: string | JsonObject | JsonArray;
+      }
+    | {
+        // GET requests can't have a body
+        method: APIMethod.GET;
+        bodyType: null;
+        body: null;
+      }
+  );
+  response: {
+    headers: Record<string, string>;
+    body: JsonValue;
+  };
+}
+
+export type ApiStepLog =
+  // Non-verbose mode
+  | BaseStepLog<LoggingNodeType.API, ApiLogMessage, LogLevel.INFO | LogLevel.ERROR>
+  // Verbose mode
+  // LogLevel.ERROR is used for both regular errors and verbose errors
+  | BaseStepLog<LoggingNodeType.API, ApiLogMessage & VerboseApiLogMessage, LogLevel.VERBOSE | LogLevel.ERROR>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/api.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/api.ts
@@ -1,5 +1,4 @@
 import { APIBodyType, APIMethod } from '@base-types/node/api';
-import { JsonArray, JsonObject, JsonValue } from 'type-fest';
 
 import { LoggingNodeType, LogLevel } from '../../utils';
 import { BaseStepLog } from '../base';
@@ -23,7 +22,7 @@ interface VerboseApiLogMessage {
     | {
         method: Exclude<APIMethod, APIMethod.GET>;
         bodyType: APIBodyType;
-        body: string | JsonObject | JsonArray;
+        body: string;
       }
     | {
         // GET requests can't have a body
@@ -34,7 +33,7 @@ interface VerboseApiLogMessage {
   );
   response: {
     headers: Record<string, string>;
-    body: JsonValue;
+    body: string;
   };
 }
 

--- a/packages/base-types/src/runtimeLogs/logs/steps/buttons.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/buttons.ts
@@ -1,0 +1,20 @@
+import { Nullable } from '@voiceflow/common';
+
+import { LoggingNodeType, PathReference } from '../../utils';
+import { BaseStepLog } from '../base';
+
+interface UrlButtonLogMessage {
+  url: Nullable<string>;
+}
+
+interface FollowPathButtonLogMessage extends UrlButtonLogMessage {
+  intent: null;
+  path: PathReference;
+}
+
+interface GoToIntentButtonLogMessage extends UrlButtonLogMessage {
+  intent: string;
+  path: null;
+}
+
+export type ButtonsStepLog = BaseStepLog<LoggingNodeType.BUTTONS, FollowPathButtonLogMessage | GoToIntentButtonLogMessage>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/capture.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/capture.ts
@@ -1,0 +1,13 @@
+import { LoggingNodeType } from '../../utils';
+import { BaseStepLog } from '../base';
+
+// TODO: Make sure there isn't other information that should be included here
+export type CaptureStepLog = BaseStepLog<
+  LoggingNodeType.CAPTURE,
+  {
+    slots: Array<{
+      utteredValue: string;
+      canonicalValue: string;
+    }>;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/code.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/code.ts
@@ -1,0 +1,20 @@
+import { LoggingNodeType, LogLevel } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type CodeStepLog =
+  | BaseStepLog<
+      LoggingNodeType.CUSTOM_CODE,
+      {
+        data: any;
+        error: null;
+      },
+      LogLevel.INFO
+    >
+  | BaseStepLog<
+      LoggingNodeType.CUSTOM_CODE,
+      {
+        data: null;
+        error: any;
+      },
+      LogLevel.ERROR
+    >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/condition.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/condition.ts
@@ -1,0 +1,9 @@
+import { LoggingNodeType, PathReference } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type ConditionStepLog = BaseStepLog<
+  LoggingNodeType.CONDITION,
+  {
+    path: PathReference;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/customAction.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/customAction.ts
@@ -1,0 +1,12 @@
+import { Nullable } from '@voiceflow/common';
+
+import { LoggingNodeType, PathReference } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type CustomActionStepLog = BaseStepLog<
+  LoggingNodeType.CUSTOM_ACTION,
+  {
+    actionBody: Nullable<string>;
+    path: PathReference;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/exit.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/exit.ts
@@ -1,0 +1,12 @@
+import { EmptyObject } from '@voiceflow/common';
+
+import { LoggingNodeType } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type ExitStepLog = BaseStepLog<
+  LoggingNodeType.EXIT,
+  {
+    /** The state of the program on exit. */
+    state: EmptyObject;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
@@ -1,0 +1,9 @@
+import { LoggingNodeType, PathReference } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type FlowStepLog = BaseStepLog<
+  LoggingNodeType.FLOW,
+  {
+    path: PathReference;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/intent.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/intent.ts
@@ -1,0 +1,16 @@
+import { LoggingNodeType } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type IntentStepLog = BaseStepLog<
+  LoggingNodeType.INTENT,
+  {
+    intentName: string;
+    utterance: string;
+    confidence: number;
+
+    slots: Array<{
+      utteredValue: string;
+      canonicalValue: string;
+    }>;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/random.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/random.ts
@@ -1,0 +1,9 @@
+import { LoggingNodeType, PathReference } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type RandomStepLog = BaseStepLog<
+  LoggingNodeType.RANDOM,
+  {
+    path: PathReference;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/set.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/set.ts
@@ -1,0 +1,10 @@
+import { LoggingNodeType } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type SetStepLog = BaseStepLog<
+  LoggingNodeType.SET,
+  {
+    variableName: string;
+    expression: string;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/speak.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/speak.ts
@@ -1,0 +1,9 @@
+import { LoggingNodeType } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type SpeakStepLog = BaseStepLog<
+  LoggingNodeType.SPEAK,
+  {
+    text: string;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/start.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/start.ts
@@ -1,0 +1,7 @@
+import { EmptyObject } from '@voiceflow/common';
+
+import { LoggingNodeType } from '../../utils';
+import { BaseStepLog } from '../base';
+
+// TODO: Consider including information from the global.conversation_start event here
+export type StartStepLog = BaseStepLog<LoggingNodeType.START, EmptyObject>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/text.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/text.ts
@@ -1,0 +1,9 @@
+import { LoggingNodeType } from '../../utils';
+import { BaseStepLog } from '../base';
+
+export type TextStepLog = BaseStepLog<
+  LoggingNodeType.TEXT,
+  {
+    text: string;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/utils/index.ts
+++ b/packages/base-types/src/runtimeLogs/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './logs';
+export * from './types';

--- a/packages/base-types/src/runtimeLogs/utils/logs.ts
+++ b/packages/base-types/src/runtimeLogs/utils/logs.ts
@@ -1,0 +1,16 @@
+export enum LogLevel {
+  ERROR = 'error',
+  WARN = 'warn',
+  INFO = 'info',
+  VERBOSE = 'verbose',
+}
+
+const logLevelValues: Readonly<Record<LogLevel, number>> = {
+  [LogLevel.ERROR]: 0,
+  [LogLevel.WARN]: 1,
+  [LogLevel.INFO]: 2,
+  [LogLevel.VERBOSE]: 3,
+};
+
+/** Returns the number (non-negative integer) value of `level`. A higher number is more verbose. `0` is the least verbose and most "important". */
+export const getValueForLogLevel = (level: LogLevel): number => logLevelValues[level];

--- a/packages/base-types/src/runtimeLogs/utils/types.ts
+++ b/packages/base-types/src/runtimeLogs/utils/types.ts
@@ -1,0 +1,44 @@
+export type Iso8601Timestamp = string;
+
+/** Similar to {@link NodeType}, but for runtime logging */
+export enum LoggingNodeType {
+  // Response
+  TEXT = 'text',
+  SPEAK = 'speak',
+  AUDIO = 'audio',
+  VISUALS = 'visuals',
+
+  // User input
+  BUTTONS = 'buttons',
+  CHOICE = 'choice',
+  CAPTURE = 'capture',
+  PROMPT = 'prompt',
+  INTENT = 'intent',
+
+  // Logic
+  CONDITION = 'condition',
+  SET = 'set',
+  RANDOM = 'random',
+  FLOW = 'flow',
+  EXIT = 'exit',
+
+  // Integration
+  API = 'api',
+  /** @deprecated Will be removed soon */
+  GOOGLE_SHEETS = 'google_sheets',
+  CUSTOM_CODE = 'custom_code',
+  CUSTOM_ACTION = 'custom_action',
+
+  // Special
+  START = 'start',
+}
+
+export enum GlobalLogKinds {
+  CONVERSATION_START = 'conversation_start',
+}
+
+/** A reference to a path on the canvas. */
+export interface PathReference {
+  componentName: LoggingNodeType;
+  stepID: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8170,11 +8170,6 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@2.12.2:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
-  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
-
 type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,6 +8200,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
+  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8170,6 +8170,11 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
+type-fest@2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
+  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
+
 type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
@@ -8199,11 +8204,6 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type-fest@^2.12.2:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
-  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
**Fixes or implements VF-3528**

### Brief description. What is this change?

adds the types for runtime log entries

a few TODO comments are lying around and should probably be addressed before merging. we can also just make edits to those TODOs or the structure of logs whenever we'd like, as long as it's before publicly launching this feature.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written