### PR TITLE
fix(base-types): make the `BaseTraceFrame` `type` field have a stricter type (VF-000)

### DIFF
--- a/packages/base-types/src/node/utils/trace.ts
+++ b/packages/base-types/src/node/utils/trace.ts
@@ -22,7 +22,7 @@ export interface BaseTraceFramePath<Event extends BaseEvent = BaseEvent> {
 }
 
 export interface BaseTraceFrame<Payload = any, TracePath extends BaseTraceFramePath = BaseTraceFramePath> {
-  type: string;
+  type: TraceType;
   paths?: TracePath[];
   payload: Payload;
   defaultPath?: number;


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

instead of a string, use the enum value that we are already using for that field anyway

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written