### PR TITLE
[Merged by Bors] - feat: add set of all channel voices (VF-3536)

### DIFF
--- a/packages/alexa-types/src/constants/base.ts
+++ b/packages/alexa-types/src/constants/base.ts
@@ -127,3 +127,5 @@ export const REGIONAL_VOICE = [
     options: [Voice.VITORIA, Voice.CAMILA, Voice.RICARDO],
   },
 ];
+
+export const ALL_ALEXA_VOICE_NAMES = new Set(Object.values(Voice));

--- a/packages/google-types/src/constants/voices.ts
+++ b/packages/google-types/src/constants/voices.ts
@@ -1211,6 +1211,4 @@ export const VoiceLanguageCodeToVoice: Record<VoiceLanguageCode, GoogleVoice[]> 
   ],
 };
 
-export const ALL_GOOGLE_VOICE_NAMES = Array.from(
-  new Set(Object.values(VoiceLanguageCodeToVoice).flatMap((value) => value.flatMap((voice) => voice.voiceName)))
-);
+export const ALL_GOOGLE_VOICE_NAMES = new Set(Object.values(VoiceLanguageCodeToVoice).flatMap((value) => value.flatMap((voice) => voice.voiceName)));

--- a/packages/google-types/src/constants/voices.ts
+++ b/packages/google-types/src/constants/voices.ts
@@ -1210,3 +1210,7 @@ export const VoiceLanguageCodeToVoice: Record<VoiceLanguageCode, GoogleVoice[]> 
     },
   ],
 };
+
+export const ALL_GOOGLE_VOICE_NAMES = Array.from(
+  new Set(Object.values(VoiceLanguageCodeToVoice).flatMap((value) => value.flatMap((voice) => voice.voiceName)))
+);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3536**

### Brief description. What is this change?

Provide a `Set` of all Alexa and Google voices. These can be used and referenced for validation of the `voice` property of a speak block.