### PR TITLE
[Merged by Bors] - feat: add ports.out.byKey type definition (VF-3575)

### DIFF
--- a/packages/base-types/src/models/base/port.ts
+++ b/packages/base-types/src/models/base/port.ts
@@ -15,9 +15,14 @@ export interface BasePort {
   target: Nullable<string>;
 }
 
-export interface BaseStepPorts<Builtin extends Partial<Record<PortType, BasePort>>, Dynamic extends BasePort[] = BasePort[]> {
+export interface BaseStepPorts<
+  Builtin extends Partial<Record<PortType, BasePort>>,
+  Dynamic extends BasePort[] = BasePort[],
+  ByKey extends Record<string, BasePort> = Record<string, BasePort>
+> {
   builtIn: Builtin;
   dynamic: Dynamic;
+  byKey: ByKey;
 }
 
 export interface AnyBaseStepPorts extends BaseStepPorts<Record<string, BasePort>, BasePort[]> {}

--- a/packages/common/src/utils/object/common.ts
+++ b/packages/common/src/utils/object/common.ts
@@ -89,3 +89,6 @@ export const omitBy: PickOmitBy = (obj: AnyRecord, predicate: (key: string, valu
  * @deprecated use pickBy instead
  */
 export const filterEntries = pickBy;
+
+export const mapValue = <T, R>(obj: Record<string | number | symbol, T>, callback: (value: T) => R) =>
+  Object.fromEntries(Object.entries(obj).map(([key, value]) => [key, callback(value)]));

--- a/packages/common/tests/utils/object/common.unit.ts
+++ b/packages/common/tests/utils/object/common.unit.ts
@@ -1,4 +1,16 @@
-import { hasProperty, isObject, omit, omitBy, pick, pickBy, selectField, selectID, selectKey, selectValue } from '@common/utils/object/common';
+import {
+  hasProperty,
+  isObject,
+  mapValue,
+  omit,
+  omitBy,
+  pick,
+  pickBy,
+  selectField,
+  selectID,
+  selectKey,
+  selectValue,
+} from '@common/utils/object/common';
 import { expect } from 'chai';
 
 describe('Utils | object | common', () => {
@@ -128,6 +140,18 @@ describe('Utils | object | common', () => {
         value2: '2',
         value5: null,
       });
+    });
+  });
+
+  describe('mapValue()', () => {
+    it('works', () => {
+      const objects = {
+        a: { id: 1 },
+        b: { id: 2 },
+        c: { id: 3 },
+      };
+
+      expect(mapValue(objects, ({ id }) => id)).to.eql({ a: 1, b: 2, c: 3 });
     });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3575**
We are introducing a new kind of port `byKey`, which should be a `Record<string, BasePort>`
With this new port, ports are connect with the data through the key, instead of relying on their position inside the array.

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->
