### PR TITLE
[Merged by Bors] - fix(base-types): expose `getValueForLogLevel()` helper function (VF-3552)

### DIFF
--- a/packages/base-types/src/runtimeLogs/index.ts
+++ b/packages/base-types/src/runtimeLogs/index.ts
@@ -1,3 +1,3 @@
 export * from './logs';
 export * from './runtime';
-export { Iso8601Timestamp, PathReference } from './utils';
+export { getValueForLogLevel, Iso8601Timestamp, PathReference } from './utils';


### PR DESCRIPTION
**Fixes or implements VF-3553**

### Brief description. What is this change?

forgot to expose this before

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written