### PR TITLE
[Merged by Bors] - fix: make byKey port partial, to have better ts typecheck (VF-3527)

### DIFF
--- a/packages/base-types/src/models/base/port.ts
+++ b/packages/base-types/src/models/base/port.ts
@@ -18,7 +18,7 @@ export interface BasePort {
 export interface BaseStepPorts<
   Builtin extends Partial<Record<PortType, BasePort>>,
   Dynamic extends BasePort[] = BasePort[],
-  ByKey extends Record<string, BasePort> = Record<string, BasePort>
+  ByKey extends Partial<Record<string, BasePort>> = Partial<Record<string, BasePort>>
 > {
   builtIn: Builtin;
   dynamic: Dynamic;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3527**

### Brief description. What is this change?

Currently Ts is not complaining in the case `({} as Record<string, BasePort>).id.something` and ideally it should, since we will not be sure if the port is present for a given key or not. 
