### PR TITLE
[Merged by Bors] - feat(base-types): more tweaks to runtime logging (VF-3552)

### DIFF
--- a/packages/base-types/src/runtimeLogs/index.ts
+++ b/packages/base-types/src/runtimeLogs/index.ts
@@ -1,3 +1,3 @@
 export * from './logs';
 export * from './runtime';
-export { getValueForLogLevel, Iso8601Timestamp, PathReference } from './utils';
+export * from './utils';

--- a/packages/base-types/src/runtimeLogs/logs/kinds.ts
+++ b/packages/base-types/src/runtimeLogs/logs/kinds.ts
@@ -8,6 +8,7 @@ export enum StepLogKind {
   AUDIO = 'audio',
   VISUALS = 'visuals',
   CARD = 'card',
+  CAROUSEL = 'carousel',
 
   // User input
   BUTTONS = 'buttons',
@@ -43,7 +44,7 @@ const NODE_TYPE_TO_STEP_LOG_KIND = {
   [NodeType.SPEAK]: StepLogKind.SPEAK,
   [NodeType.START]: StepLogKind.START,
   [NodeType.CARD]: StepLogKind.CARD,
-  [NodeType.CARDV2]: StepLogKind.CARD,
+  [NodeType.CAROUSEL]: StepLogKind.CAROUSEL,
   [NodeType.BUTTONS]: StepLogKind.BUTTONS,
 
   [NodeType.SET]: StepLogKind.SET,

--- a/packages/base-types/src/runtimeLogs/logs/kinds.ts
+++ b/packages/base-types/src/runtimeLogs/logs/kinds.ts
@@ -1,3 +1,5 @@
+import { NodeType } from '@base-types/node';
+
 /** Similar to {@link NodeType}, but for runtime logging */
 export enum StepLogKind {
   // Response
@@ -5,6 +7,7 @@ export enum StepLogKind {
   SPEAK = 'speak',
   AUDIO = 'audio',
   VISUALS = 'visuals',
+  CARD = 'card',
 
   // User input
   BUTTONS = 'buttons',
@@ -33,4 +36,43 @@ export enum StepLogKind {
 
 export enum GlobalLogKind {
   CONVERSATION_START = 'conversation_start',
+}
+
+const NODE_TYPE_TO_STEP_LOG_KIND = {
+  [NodeType.TEXT]: StepLogKind.TEXT,
+  [NodeType.SPEAK]: StepLogKind.SPEAK,
+  [NodeType.START]: StepLogKind.START,
+  [NodeType.CARD]: StepLogKind.CARD,
+  [NodeType.CARDV2]: StepLogKind.CARD,
+  [NodeType.BUTTONS]: StepLogKind.BUTTONS,
+
+  [NodeType.SET]: StepLogKind.SET,
+  [NodeType.SET_V2]: StepLogKind.SET,
+  [NodeType.IF]: StepLogKind.CONDITION,
+  [NodeType.IF_V2]: StepLogKind.CONDITION,
+  [NodeType.RANDOM]: StepLogKind.RANDOM,
+  [NodeType.CAPTURE]: StepLogKind.CAPTURE,
+  [NodeType.CAPTURE_V2]: StepLogKind.CAPTURE,
+
+  [NodeType.API]: StepLogKind.API,
+  /** @deprecated */
+  [NodeType.GOOGLE_SHEETS]: StepLogKind.GOOGLE_SHEETS,
+
+  [NodeType.INTENT]: StepLogKind.INTENT,
+  [NodeType.CODE]: StepLogKind.CUSTOM_CODE,
+  [NodeType.EXIT]: StepLogKind.EXIT,
+  [NodeType.PROMPT]: StepLogKind.PROMPT,
+
+  [NodeType.VISUAL]: StepLogKind.VISUALS,
+} as const;
+
+type MappableNodeType = keyof typeof NODE_TYPE_TO_STEP_LOG_KIND;
+type NonMappableNodeType = Exclude<NodeType, MappableNodeType>;
+
+export function nodeTypeToStepLogKind(nodeType: MappableNodeType): StepLogKind;
+export function nodeTypeToStepLogKind(nodeType: NonMappableNodeType): undefined;
+export function nodeTypeToStepLogKind(nodeType: NodeType): StepLogKind | undefined;
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+export function nodeTypeToStepLogKind(nodeType: NodeType): StepLogKind | undefined {
+  return nodeType in NODE_TYPE_TO_STEP_LOG_KIND ? NODE_TYPE_TO_STEP_LOG_KIND[nodeType as MappableNodeType] : undefined;
 }

--- a/packages/base-types/src/runtimeLogs/logs/levels.ts
+++ b/packages/base-types/src/runtimeLogs/logs/levels.ts
@@ -1,4 +1,6 @@
 export enum LogLevel {
+  /** This is a special log level. No logs should ever use this, its only use is denoting when logging should be disabled. */
+  OFF = 'off',
   ERROR = 'error',
   WARN = 'warn',
   INFO = 'info',

--- a/packages/base-types/src/runtimeLogs/logs/steps/api.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/api.ts
@@ -4,43 +4,61 @@ import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 import { LogLevel } from '../levels';
 
+interface ApiLogMessageRequest {
+  method: APIMethod;
+  url: string;
+  headers: null;
+  query: null;
+  bodyType: null;
+  body: null;
+}
+
+interface ApiLogMessageResponse {
+  statusCode: number;
+  statusMessage: string;
+  headers: null;
+  body: null;
+}
+
 interface ApiLogMessage {
-  request: {
-    method: APIMethod;
-    url: string;
-  };
-  response: {
-    statusCode: number;
-    statusMessage: string;
-  };
+  request: ApiLogMessageRequest;
+  response: ApiLogMessageResponse;
+}
+
+type VerboseApiLogMessageRequest = {
+  url: string;
+  headers: Record<string, string>;
+  query: Record<string, string>;
+} & (
+  | {
+      method: Exclude<APIMethod, APIMethod.GET>;
+      bodyType: APIBodyType;
+      body: string;
+    }
+  | {
+      // GET requests can't have a body
+      method: APIMethod.GET;
+      bodyType: null;
+      body: null;
+    }
+);
+
+interface VerboseApiLogMessageResponse {
+  statusCode: number;
+  statusMessage: string;
+  headers: Record<string, string>;
+  body: string;
 }
 
 interface VerboseApiLogMessage {
-  request: {
-    headers: Record<string, string>;
-    query: Record<string, string>;
-  } & (
-    | {
-        method: Exclude<APIMethod, APIMethod.GET>;
-        bodyType: APIBodyType;
-        body: string;
-      }
-    | {
-        // GET requests can't have a body
-        method: APIMethod.GET;
-        bodyType: null;
-        body: null;
-      }
-  );
-  response: {
-    headers: Record<string, string>;
-    body: string;
-  };
+  request: VerboseApiLogMessageRequest;
+  response: VerboseApiLogMessageResponse;
 }
 
 export type ApiStepLog =
   // Non-verbose mode
-  | BaseStepLog<StepLogKind.API, ApiLogMessage, LogLevel.INFO | LogLevel.ERROR>
+  | BaseStepLog<StepLogKind.API, ApiLogMessage, LogLevel.INFO>
   // Verbose mode
+  | BaseStepLog<StepLogKind.API, VerboseApiLogMessage, LogLevel.VERBOSE>
   // LogLevel.ERROR is used for both regular errors and verbose errors
-  | BaseStepLog<StepLogKind.API, ApiLogMessage & VerboseApiLogMessage, LogLevel.VERBOSE | LogLevel.ERROR>;
+  | BaseStepLog<StepLogKind.API, ApiLogMessage | VerboseApiLogMessage, LogLevel.ERROR>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/code.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/code.ts
@@ -11,7 +11,6 @@ export type CodeStepLog =
   | BaseStepLog<
       StepLogKind.CUSTOM_CODE,
       {
-        data: any;
         error: null;
         changedVariables: Record<string, ChangedVariable<any>>;
       },
@@ -20,9 +19,8 @@ export type CodeStepLog =
   | BaseStepLog<
       StepLogKind.CUSTOM_CODE,
       {
-        data: null;
         error: any;
-        changedVariables: Record<string, ChangedVariable<any>>;
+        changedVariables: null;
       },
       LogLevel.ERROR
     >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/code.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/code.ts
@@ -2,12 +2,18 @@ import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 import { LogLevel } from '../levels';
 
+interface ChangedVariable<T> {
+  before: T;
+  after: T;
+}
+
 export type CodeStepLog =
   | BaseStepLog<
       StepLogKind.CUSTOM_CODE,
       {
         data: any;
         error: null;
+        changedVariables: Record<string, ChangedVariable<any>>;
       },
       LogLevel.INFO
     >
@@ -16,6 +22,7 @@ export type CodeStepLog =
       {
         data: null;
         error: any;
+        changedVariables: Record<string, ChangedVariable<any>>;
       },
       LogLevel.ERROR
     >;

--- a/packages/base-types/src/runtimeLogs/runtime/logBuffer.ts
+++ b/packages/base-types/src/runtimeLogs/runtime/logBuffer.ts
@@ -9,7 +9,7 @@ export interface LogBuffer {
   readonly bufferSize: number;
 
   /** Add {@link Log} to this {@link LogBuffer}'s buffer. */
-  push(...logs: Log[]): void;
+  push(...logs: readonly Log[]): void;
   /** Dispatch all {@link Log} from this {@link LogBuffer}'s buffer and then remove them. */
   flush(): void;
   /** Remove all {@link Log} from this {@link LogBuffer}'s buffer. */

--- a/packages/base-types/src/runtimeLogs/utils/logs.ts
+++ b/packages/base-types/src/runtimeLogs/utils/logs.ts
@@ -9,3 +9,9 @@ const logLevelValues: Readonly<Record<LogLevel, number>> = {
 
 /** Returns the number (non-negative integer) value of `level`. A higher number is more verbose. `0` is the least verbose and most "important". */
 export const getValueForLogLevel = (level: LogLevel): number => logLevelValues[level];
+
+const ALL_LOG_LEVELS: ReadonlySet<LogLevel> = new Set(Object.values(LogLevel));
+
+export const isLogLevel = (level: string): level is LogLevel => {
+  return ALL_LOG_LEVELS.has(level as any);
+};

--- a/packages/base-types/src/runtimeLogs/utils/logs.ts
+++ b/packages/base-types/src/runtimeLogs/utils/logs.ts
@@ -1,13 +1,14 @@
 import { LogLevel } from '../logs/levels';
 
 const logLevelValues: Readonly<Record<LogLevel, number>> = {
+  [LogLevel.OFF]: -1,
   [LogLevel.ERROR]: 0,
   [LogLevel.WARN]: 1,
   [LogLevel.INFO]: 2,
   [LogLevel.VERBOSE]: 3,
 };
 
-/** Returns the number (non-negative integer) value of `level`. A higher number is more verbose. `0` is the least verbose and most "important". */
+/** Returns the number (non-negative integer) value of `level`. A higher number is more verbose. `0` is the least verbose and most "important". The value `-1` is used to disable logging. */
 export const getValueForLogLevel = (level: LogLevel): number => logLevelValues[level];
 
 const ALL_LOG_LEVELS: ReadonlySet<LogLevel> = new Set(Object.values(LogLevel));


### PR DESCRIPTION
**Fixes or implements VF-3552**

### Brief description. What is this change?

more minor changes to runtime logging utils & types

- add `LogLevel.OFF`
- `export *` for utils (just remember not to export anything that should be private/internal)
- narrowing types
- add type guard for narrowing `string` to `LogLevel`
- updating the messages for various logs
- a `nodeTypeToStepLogKind()` method for converting `NodeType` to human-friendly `StepLogKind` values

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written