### PR TITLE
[Merged by Bors] - feat: added manualSave and autoSaveFromRestore types (VF-3631)

### DIFF
--- a/packages/base-types/src/models/version/index.ts
+++ b/packages/base-types/src/models/version/index.ts
@@ -53,4 +53,7 @@ export interface Model<_PlatformData extends PlatformData, Command extends BaseC
   prototype?: Prototype<Command, Locale>;
   components?: FolderItem[];
   platformData: _PlatformData;
+
+  manualSave?: boolean;
+  autoSaveFromRestore?: boolean;
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3631**

### Brief description. What is this change?

Adds `manualSave` and `autoSaveFromRestore` to the versions model. These properties already exist and can be generated by the `creator-api`, however, there is no way to access these fields from the type.

### Implementation details. How do you make this change?

Added the two properties as optional boolean fields.

### Setup information

N/A

### Deployment Notes

N/A

### Related PRs

N/A

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
