### PR TITLE
[Merged by Bors] - feat(base-types): update runtime logging types for batch 1 of steps (VF-3554)

### DIFF
--- a/packages/base-types/src/runtimeLogs/logs/steps/random.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/random.ts
@@ -5,6 +5,6 @@ import { StepLogKind } from '../kinds';
 export type RandomStepLog = BaseStepLog<
   StepLogKind.RANDOM,
   {
-    path: PathReference;
+    path: PathReference | null;
   }
 >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/set.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/set.ts
@@ -1,10 +1,6 @@
+import { ChangedVariables } from '@base-types/runtimeLogs/utils';
+
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
-export type SetStepLog = BaseStepLog<
-  StepLogKind.SET,
-  {
-    variableName: string;
-    expression: string;
-  }
->;
+export type SetStepLog = BaseStepLog<StepLogKind.SET, ChangedVariables<any>>;

--- a/packages/base-types/src/runtimeLogs/utils/types.ts
+++ b/packages/base-types/src/runtimeLogs/utils/types.ts
@@ -7,3 +7,17 @@ export interface PathReference {
   componentName: StepLogKind;
   stepID: string;
 }
+
+/** A common interface for representing a before & after change of a value. */
+export interface ValueChange<T> {
+  before: T;
+  after: T;
+}
+
+/**
+ * An abstract interface for something that includes changed variables.
+ * This enforces a consistent naming scheme of the property.
+ */
+export interface ChangedVariables<V, K extends PropertyKey = string> {
+  changedVariables: Record<K, ValueChange<V>>;
+}


### PR DESCRIPTION
**Fixes or implements VF-3554**
**Fixes or implements VF-3819**
**Fixes or implements VF-3820**
**Fixes or implements VF-3829**

### Brief description. What is this change?

updates the types to facilitate implementing runtime logging for the random and set steps

### Related PRs

- https://github.com/voiceflow/general-runtime/pull/336

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written