### PR TITLE
[Merged by Bors] - feat: components reorder (VF-2781)

### DIFF
--- a/packages/api-sdk/src/resources/version.ts
+++ b/packages/api-sdk/src/resources/version.ts
@@ -208,8 +208,15 @@ class VersionResource extends CrudResource<BaseModels.Version.Model<BaseModels.V
     return data;
   }
 
-  public async reorderTopics<P extends { fromID: string; toIndex: number }>(id: string, body: P): Promise<string> {
-    const { data } = await this.fetch.patch<string>(`${this._getCRUDEndpoint(id)}/topics/reorder`, body);
+  public async reorderTopics(id: string, body: { fromID: string; toIndex: number }): Promise<BaseModels.Version.FolderItem> {
+    const { data } = await this.fetch.patch<BaseModels.Version.FolderItem>(`${this._getCRUDEndpoint(id)}/topics/reorder`, body);
+
+    return data;
+  }
+
+  public async reorderComponents(id: string, body: { fromID: string; toIndex: number }): Promise<BaseModels.Version.FolderItem> {
+    const { data } = await this.fetch.patch<BaseModels.Version.FolderItem>(`${this._getCRUDEndpoint(id)}/components/reorder`, body);
+
     return data;
   }
 }

--- a/packages/api-sdk/tests/resources/version.unit.ts
+++ b/packages/api-sdk/tests/resources/version.unit.ts
@@ -389,7 +389,7 @@ describe('VersionResource', () => {
     const fromID = 'fromID-1';
     const toIndex = 1;
 
-    const response = { data: 'fromID-1' };
+    const response = { data: { sourceID: 'fromID-1' } };
 
     fetch.patch.resolves(response);
 
@@ -399,6 +399,25 @@ describe('VersionResource', () => {
 
     expect(fetch.patch.callCount).to.eql(1);
     expect(fetch.patch.args[0]).to.eql([`versions/${versionID}/topics/reorder`, { fromID, toIndex }]);
+    expect(data).to.eql(response.data);
+  });
+
+  it('reorderComponents', async () => {
+    const { fetch, resource } = createClient();
+
+    const fromID = 'fromID-1';
+    const toIndex = 1;
+
+    const response = { data: { sourceID: 'fromID-1' } };
+
+    fetch.patch.resolves(response);
+
+    const versionID = '1';
+
+    const data = await resource.reorderComponents(versionID, { fromID, toIndex });
+
+    expect(fetch.patch.callCount).to.eql(1);
+    expect(fetch.patch.args[0]).to.eql([`versions/${versionID}/components/reorder`, { fromID, toIndex }]);
     expect(data).to.eql(response.data);
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2781**

### Brief description. What is this change?

- add reorder components method

### Related PRs

- https://github.com/voiceflow/creator-api/pull/1008

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
