### PR TITLE
[Merged by Bors] - feat(base-types): update runtime logging types for batch 2 of steps (VF-3554)

### DIFF
--- a/packages/base-types/src/runtimeLogs/logs/steps/condition.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/condition.ts
@@ -5,6 +5,6 @@ import { StepLogKind } from '../kinds';
 export type ConditionStepLog = BaseStepLog<
   StepLogKind.CONDITION,
   {
-    path: PathReference;
+    path: PathReference | null;
   }
 >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
@@ -1,10 +1,5 @@
-import { PathReference } from '../../utils';
+import { FlowReference, ValueChange } from '../../utils';
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
-export type FlowStepLog = BaseStepLog<
-  StepLogKind.FLOW,
-  {
-    path: PathReference;
-  }
->;
+export type FlowStepLog = BaseStepLog<StepLogKind.FLOW, ValueChange<FlowReference>>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/text.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/text.ts
@@ -1,9 +1,12 @@
+import { Text as TextNode } from '@base-types/node';
+
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
 export type TextStepLog = BaseStepLog<
   StepLogKind.TEXT,
   {
-    text: string;
+    plainContent: string;
+    richContent: TextNode.TextData;
   }
 >;

--- a/packages/base-types/src/runtimeLogs/utils/types.ts
+++ b/packages/base-types/src/runtimeLogs/utils/types.ts
@@ -8,6 +8,12 @@ export interface PathReference {
   stepID: string;
 }
 
+/** A reference to a flow (frame) on the canvas. */
+export interface FlowReference {
+  name: string | null;
+  programID: string;
+}
+
 /** A common interface for representing a before & after change of a value. */
 export interface ValueChange<T> {
   before: T;


### PR DESCRIPTION
**Fixes or implements VF-3554**
**Fixes or implements VF-3824**
**Fixes or implements VF-3825**
**Fixes or implements VF-3828**
**Fixes or implements VF-3832**

### Brief description. What is this change?

updates the types to facilitate implementing runtime logging for the condition, flow, and text steps

### Related PRs

- https://github.com/voiceflow/general-runtime/pull/338

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written