### PR TITLE
[Merged by Bors] - feat: revert adding stop on trace node (VF-3675)

### DIFF
--- a/packages/base-types/src/node/utils/trace.ts
+++ b/packages/base-types/src/node/utils/trace.ts
@@ -28,5 +28,4 @@ export interface BaseTraceFrame<Payload = any, TracePath extends BaseTraceFrameP
   paths?: TracePath[];
   payload: Payload;
   defaultPath?: number;
-  stop?: boolean;
 }


### PR DESCRIPTION
**Fixes or implements VF-3675**

### Brief description. What is this change?

Reverts adding stop on trace node, after discussing it with @trs  it doesnt make sense to have it there