### PR TITLE
[Merged by Bors] - feat(base-types): update runtime logging types for batch 3 of steps (VF-3554)

### DIFF
--- a/packages/base-types/src/runtimeLogs/logs/base.ts
+++ b/packages/base-types/src/runtimeLogs/logs/base.ts
@@ -1,6 +1,6 @@
 import { EmptyObject } from '@voiceflow/common';
 
-import { Iso8601Timestamp, PathReference } from '../utils';
+import { DEFAULT_LOG_LEVEL, Iso8601Timestamp, PathReference } from '../utils';
 import { GlobalLogKind, StepLogKind } from './kinds';
 import { LogLevel } from './levels';
 
@@ -12,13 +12,15 @@ interface BaseLog {
   level: LogLevel;
 }
 
-export interface BaseGlobalLog<Kind extends GlobalLogKind, Message extends EmptyObject, Level extends LogLevel = LogLevel.INFO> extends BaseLog {
+export interface BaseGlobalLog<Kind extends GlobalLogKind, Message extends EmptyObject, Level extends LogLevel = typeof DEFAULT_LOG_LEVEL>
+  extends BaseLog {
   kind: `global.${Kind}`;
   level: Level;
   message: Message;
 }
 
-export interface BaseStepLog<Kind extends StepLogKind, Message extends EmptyObject, Level extends LogLevel = LogLevel.INFO> extends BaseLog {
+export interface BaseStepLog<Kind extends StepLogKind, Message extends EmptyObject, Level extends LogLevel = typeof DEFAULT_LOG_LEVEL>
+  extends BaseLog {
   kind: `step.${Kind}`;
   level: Level;
   message: PathReference & Message;

--- a/packages/base-types/src/runtimeLogs/logs/global/nluIntentResolved.ts
+++ b/packages/base-types/src/runtimeLogs/logs/global/nluIntentResolved.ts
@@ -1,0 +1,16 @@
+import { BaseGlobalLog } from '../base';
+import { GlobalLogKind } from '../kinds';
+
+interface Entity {
+  value: string;
+}
+
+export type NluIntentResolvedLog = BaseGlobalLog<
+  GlobalLogKind.NLU_INTENT_RESOLVED,
+  {
+    resolvedIntent: string;
+    confidence: number;
+    utterance: string;
+    entities: Record<string, Entity>;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/logs/kinds.ts
+++ b/packages/base-types/src/runtimeLogs/logs/kinds.ts
@@ -37,6 +37,7 @@ export enum StepLogKind {
 
 export enum GlobalLogKind {
   CONVERSATION_START = 'conversation_start',
+  NLU_INTENT_RESOLVED = 'nlu.intent_resolved',
 }
 
 const NODE_TYPE_TO_STEP_LOG_KIND = {

--- a/packages/base-types/src/runtimeLogs/logs/logs.ts
+++ b/packages/base-types/src/runtimeLogs/logs/logs.ts
@@ -1,4 +1,5 @@
 import { ConversationStartLog } from './global/conversationStart';
+import { NluIntentResolvedLog } from './global/nluIntentResolved';
 import { ApiStepLog } from './steps/api';
 import { ButtonsStepLog } from './steps/buttons';
 import { CaptureStepLog } from './steps/capture';
@@ -33,7 +34,7 @@ export {
 };
 
 /** All possible runtime logs for global events. */
-export type GlobalLog = ConversationStartLog;
+export type GlobalLog = ConversationStartLog | NluIntentResolvedLog;
 
 /** All possible runtime logs for steps. */
 export type StepLog =

--- a/packages/base-types/src/runtimeLogs/logs/steps/api.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/api.ts
@@ -15,7 +15,7 @@ interface ApiLogMessageRequest {
 
 interface ApiLogMessageResponse {
   statusCode: number;
-  statusMessage: string;
+  statusText: string;
   headers: null;
   body: null;
 }
@@ -45,7 +45,7 @@ type VerboseApiLogMessageRequest = {
 
 interface VerboseApiLogMessageResponse {
   statusCode: number;
-  statusMessage: string;
+  statusText: string;
   headers: Record<string, string>;
   body: string;
 }

--- a/packages/base-types/src/runtimeLogs/logs/steps/capture.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/capture.ts
@@ -1,13 +1,6 @@
+import { ChangedVariables, VariableValue } from '@base-types/runtimeLogs/utils';
+
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
-// TODO: Make sure there isn't other information that should be included here
-export type CaptureStepLog = BaseStepLog<
-  StepLogKind.CAPTURE,
-  {
-    slots: Array<{
-      utteredValue: string;
-      canonicalValue: string;
-    }>;
-  }
->;
+export type CaptureStepLog = BaseStepLog<StepLogKind.CAPTURE, ChangedVariables<VariableValue | null, string, VariableValue>>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/code.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/code.ts
@@ -1,26 +1,21 @@
+import { ChangedVariables } from '@base-types/runtimeLogs/utils';
+
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 import { LogLevel } from '../levels';
-
-interface ChangedVariable<T> {
-  before: T;
-  after: T;
-}
 
 export type CodeStepLog =
   | BaseStepLog<
       StepLogKind.CUSTOM_CODE,
       {
         error: null;
-        changedVariables: Record<string, ChangedVariable<any>>;
-      },
+      } & ChangedVariables<any>,
       LogLevel.INFO
     >
   | BaseStepLog<
       StepLogKind.CUSTOM_CODE,
       {
         error: any;
-        changedVariables: null;
-      },
+      } & Record<keyof ChangedVariables<never>, null>,
       LogLevel.ERROR
     >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
@@ -2,4 +2,9 @@ import { FlowReference, ValueChange } from '../../utils';
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
-export type FlowStepLog = BaseStepLog<StepLogKind.FLOW, ValueChange<FlowReference>>;
+export type FlowStepLog = BaseStepLog<
+  StepLogKind.FLOW,
+  {
+    flow: null | ValueChange<FlowReference>;
+  }
+>;

--- a/packages/base-types/src/runtimeLogs/utils/logs.ts
+++ b/packages/base-types/src/runtimeLogs/utils/logs.ts
@@ -16,3 +16,5 @@ const ALL_LOG_LEVELS: ReadonlySet<LogLevel> = new Set(Object.values(LogLevel));
 export const isLogLevel = (level: string): level is LogLevel => {
   return ALL_LOG_LEVELS.has(level as any);
 };
+
+export const DEFAULT_LOG_LEVEL = LogLevel.INFO;

--- a/packages/base-types/src/runtimeLogs/utils/types.ts
+++ b/packages/base-types/src/runtimeLogs/utils/types.ts
@@ -15,15 +15,17 @@ export interface FlowReference {
 }
 
 /** A common interface for representing a before & after change of a value. */
-export interface ValueChange<T> {
-  before: T;
-  after: T;
+export interface ValueChange<Before, After = Before> {
+  before: Before;
+  after: After;
 }
 
 /**
  * An abstract interface for something that includes changed variables.
  * This enforces a consistent naming scheme of the property.
  */
-export interface ChangedVariables<V, K extends PropertyKey = string> {
-  changedVariables: Record<K, ValueChange<V>>;
+export interface ChangedVariables<V, K extends PropertyKey = string, V2 = V> {
+  changedVariables: Record<K, ValueChange<V, V2>>;
 }
+
+export type VariableValue = string | number;


### PR DESCRIPTION
**Fixes or implements VF-3554**
**Fixes or implements VF-3821**
**Fixes or implements VF-3822**
**Fixes or implements VF-3823**
**Fixes or implements VF-3828**
**Fixes or implements VF-3833**
**Fixes or implements VF-3834**

### Brief description. What is this change?

adds or updates types for the third batch of runtime logs

### Related PRs

- https://github.com/voiceflow/general-runtime/pull/355

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written