### PR TITLE
[Merged by Bors] - fix: new email regex (VF-3921)

### DIFF
--- a/packages/common/src/utils/emails.ts
+++ b/packages/common/src/utils/emails.ts
@@ -1,5 +1,5 @@
-const FORMAT = /^\w+(['+-.]\w+)*@\w+([.-]\w+)*\.\w+([.-]\w+)*$/;
+const FORMAT = /^[\w!#$%&'*+./=?^`{|}~-]+@[\dA-Za-z](?:[\dA-Za-z-]{0,61}[\dA-Za-z])?(?:\.[\dA-Za-z](?:[\dA-Za-z-]{0,61}[\dA-Za-z])?)*$/;
 
-export const isValidEmail = (email: string): boolean => !!email.match(FORMAT);
+export const isValidEmail = (email: string): boolean => email.length < 320 && FORMAT.test(email);
 
 export const getEmailDomain = (email: string): string => email.slice(Math.max(0, email.lastIndexOf('@') + 1));

--- a/packages/common/tests/utils/email.unit.ts
+++ b/packages/common/tests/utils/email.unit.ts
@@ -1,0 +1,26 @@
+import { getEmailDomain, isValidEmail } from '@common/utils/emails';
+import { expect } from 'chai';
+
+describe('Utils | email', () => {
+  describe('isValid()', () => {
+    it('should be valid', () => {
+      const validEmails = ['joe.doe@test.com', 'john.-last@sub.domain.com', 'test+@voiceflow.com', 't-est+34@voice-flow.com'];
+
+      validEmails.forEach((email) => expect(isValidEmail(email)).to.eq(true));
+    });
+
+    it('should be invalid', () => {
+      const invalidEmails = ['joe@.com', 'joe@', '@voiceflow.com', '', 'voiceflow.com'];
+
+      invalidEmails.forEach((email) => expect(isValidEmail(email)).to.eq(false));
+    });
+  });
+
+  describe('getEmailDomain()', () => {
+    it('works', () => {
+      expect(getEmailDomain('test@voiceflow.com')).to.eq('voiceflow.com');
+      expect(getEmailDomain('')).to.eq('');
+      expect(getEmailDomain('totally@invalid@voiceflow.com')).to.eq('voiceflow.com');
+    });
+  });
+});


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3921**

### Brief description. What is this change?

Turns out this is a valid email that our current regex was not happy about: 
`test.-test@voiceflow.com`

I've updated the regex to be even more comprehensive - ripped it right off the segementio one:
https://github.com/segmentio/is-email/blob/master/lib/index.js

added some tests too.