### PR TITLE
[Merged by Bors] - fix(base-types): small fixes to types for runtime logging (VF-000)

### DIFF
--- a/packages/base-types/src/runtimeLogs/logs/base.ts
+++ b/packages/base-types/src/runtimeLogs/logs/base.ts
@@ -9,18 +9,24 @@ interface BaseLog {
   kind: string;
   timestamp: Iso8601Timestamp;
   message: EmptyObject;
-  level: LogLevel;
+  level: Exclude<LogLevel, LogLevel.OFF>;
 }
 
-export interface BaseGlobalLog<Kind extends GlobalLogKind, Message extends EmptyObject, Level extends LogLevel = typeof DEFAULT_LOG_LEVEL>
-  extends BaseLog {
+export interface BaseGlobalLog<
+  Kind extends GlobalLogKind,
+  Message extends EmptyObject,
+  Level extends Exclude<LogLevel, LogLevel.OFF> = typeof DEFAULT_LOG_LEVEL
+> extends BaseLog {
   kind: `global.${Kind}`;
   level: Level;
   message: Message;
 }
 
-export interface BaseStepLog<Kind extends StepLogKind, Message extends EmptyObject, Level extends LogLevel = typeof DEFAULT_LOG_LEVEL>
-  extends BaseLog {
+export interface BaseStepLog<
+  Kind extends StepLogKind,
+  Message extends EmptyObject,
+  Level extends Exclude<LogLevel, LogLevel.OFF> = typeof DEFAULT_LOG_LEVEL
+> extends BaseLog {
   kind: `step.${Kind}`;
   level: Level;
   message: PathReference & Message;

--- a/packages/base-types/src/runtimeLogs/logs/logs.ts
+++ b/packages/base-types/src/runtimeLogs/logs/logs.ts
@@ -26,6 +26,7 @@ export {
   ExitStepLog,
   FlowStepLog,
   IntentStepLog,
+  NluIntentResolvedLog,
   RandomStepLog,
   SetStepLog,
   SpeakStepLog,


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

- export the `NluIntentResolvedLog` interface (i forgot to do this when i originally added it)
- exclude `LogLevel.OFF` from log entries (if logging is disabled you shouldn't be able to create a log object)

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written