### PR TITLE
[Merged by Bors] - feat: make the node for speak and text logs nullable (VF-4103)

### DIFF
--- a/packages/base-types/src/runtimeLogs/logs/base.ts
+++ b/packages/base-types/src/runtimeLogs/logs/base.ts
@@ -23,5 +23,5 @@ export interface BaseStepLog<Kind extends StepLogKind, Message extends EmptyObje
   extends BaseLog {
   kind: `step.${Kind}`;
   level: Level;
-  message: PathReference & Message;
+  message: Message;
 }

--- a/packages/base-types/src/runtimeLogs/logs/base.ts
+++ b/packages/base-types/src/runtimeLogs/logs/base.ts
@@ -1,6 +1,6 @@
 import { EmptyObject } from '@voiceflow/common';
 
-import { DEFAULT_LOG_LEVEL, Iso8601Timestamp, PathReference } from '../utils';
+import { DEFAULT_LOG_LEVEL, Iso8601Timestamp } from '../utils';
 import { GlobalLogKind, StepLogKind } from './kinds';
 import { LogLevel } from './levels';
 

--- a/packages/base-types/src/runtimeLogs/logs/steps/api.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/api.ts
@@ -1,4 +1,5 @@
 import { APIBodyType, APIMethod } from '@base-types/node/api';
+import { PathReference } from '@base-types/runtimeLogs/utils';
 
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
@@ -57,8 +58,8 @@ interface VerboseApiLogMessage {
 
 export type ApiStepLog =
   // Non-verbose mode
-  | BaseStepLog<StepLogKind.API, ApiLogMessage, LogLevel.INFO>
+  | BaseStepLog<StepLogKind.API, PathReference & ApiLogMessage, LogLevel.INFO>
   // Verbose mode
-  | BaseStepLog<StepLogKind.API, VerboseApiLogMessage, LogLevel.VERBOSE>
+  | BaseStepLog<StepLogKind.API, PathReference & VerboseApiLogMessage, LogLevel.VERBOSE>
   // LogLevel.ERROR is used for both regular errors and verbose errors
-  | BaseStepLog<StepLogKind.API, ApiLogMessage | VerboseApiLogMessage, LogLevel.ERROR>;
+  | BaseStepLog<StepLogKind.API, PathReference & (ApiLogMessage | VerboseApiLogMessage), LogLevel.ERROR>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/buttons.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/buttons.ts
@@ -18,4 +18,4 @@ interface GoToIntentButtonLogMessage extends UrlButtonLogMessage {
   path: null;
 }
 
-export type ButtonsStepLog = BaseStepLog<StepLogKind.BUTTONS, FollowPathButtonLogMessage | GoToIntentButtonLogMessage>;
+export type ButtonsStepLog = BaseStepLog<StepLogKind.BUTTONS, PathReference & (FollowPathButtonLogMessage | GoToIntentButtonLogMessage)>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/capture.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/capture.ts
@@ -1,6 +1,6 @@
-import { ChangedVariables, VariableValue } from '@base-types/runtimeLogs/utils';
+import { ChangedVariables, PathReference, VariableValue } from '@base-types/runtimeLogs/utils';
 
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
-export type CaptureStepLog = BaseStepLog<StepLogKind.CAPTURE, ChangedVariables<VariableValue | null, string, VariableValue>>;
+export type CaptureStepLog = BaseStepLog<StepLogKind.CAPTURE, PathReference & ChangedVariables<VariableValue | null, string, VariableValue>>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/code.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/code.ts
@@ -1,4 +1,4 @@
-import { ChangedVariables } from '@base-types/runtimeLogs/utils';
+import { ChangedVariables, PathReference } from '@base-types/runtimeLogs/utils';
 
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
@@ -7,14 +7,14 @@ import { LogLevel } from '../levels';
 export type CodeStepLog =
   | BaseStepLog<
       StepLogKind.CUSTOM_CODE,
-      {
+      PathReference & {
         error: null;
       } & ChangedVariables<any>,
       LogLevel.INFO
     >
   | BaseStepLog<
       StepLogKind.CUSTOM_CODE,
-      {
+      PathReference & {
         error: any;
       } & Record<keyof ChangedVariables<never>, null>,
       LogLevel.ERROR

--- a/packages/base-types/src/runtimeLogs/logs/steps/condition.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/condition.ts
@@ -4,7 +4,7 @@ import { StepLogKind } from '../kinds';
 
 export type ConditionStepLog = BaseStepLog<
   StepLogKind.CONDITION,
-  {
+  PathReference & {
     path: PathReference | null;
   }
 >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/customAction.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/customAction.ts
@@ -6,7 +6,7 @@ import { StepLogKind } from '../kinds';
 
 export type CustomActionStepLog = BaseStepLog<
   StepLogKind.CUSTOM_ACTION,
-  {
+  Record<keyof PathReference, null> & {
     actionBody: Nullable<string>;
     path: PathReference;
   }

--- a/packages/base-types/src/runtimeLogs/logs/steps/exit.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/exit.ts
@@ -1,3 +1,4 @@
+import { PathReference } from '@base-types/runtimeLogs/utils';
 import { EmptyObject } from '@voiceflow/common';
 
 import { BaseStepLog } from '../base';
@@ -8,7 +9,7 @@ export type ExitStepLog =
   // Non-verbose mode doesn't include the state
   | BaseStepLog<
       StepLogKind.EXIT,
-      {
+      PathReference & {
         state: null;
       },
       LogLevel.INFO
@@ -16,7 +17,7 @@ export type ExitStepLog =
   // Verbose mode
   | BaseStepLog<
       StepLogKind.EXIT,
-      {
+      PathReference & {
         /** The state of the program on exit. */
         state: EmptyObject;
       },

--- a/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/flow.ts
@@ -1,10 +1,11 @@
-import { FlowReference, ValueChange } from '../../utils';
+import { FlowReference, PathReference, ValueChange } from '@base-types/runtimeLogs/utils';
+
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
 export type FlowStepLog = BaseStepLog<
   StepLogKind.FLOW,
-  {
+  PathReference & {
     flow: null | ValueChange<FlowReference>;
   }
 >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/intent.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/intent.ts
@@ -1,9 +1,11 @@
+import { PathReference } from '@base-types/runtimeLogs/utils';
+
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
 export type IntentStepLog = BaseStepLog<
   StepLogKind.INTENT,
-  {
+  PathReference & {
     intentName: string;
     utterance: string;
     confidence: number;

--- a/packages/base-types/src/runtimeLogs/logs/steps/random.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/random.ts
@@ -4,7 +4,7 @@ import { StepLogKind } from '../kinds';
 
 export type RandomStepLog = BaseStepLog<
   StepLogKind.RANDOM,
-  {
+  PathReference & {
     path: PathReference | null;
   }
 >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/set.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/set.ts
@@ -1,6 +1,6 @@
-import { ChangedVariables } from '@base-types/runtimeLogs/utils';
+import { ChangedVariables, PathReference } from '@base-types/runtimeLogs/utils';
 
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
-export type SetStepLog = BaseStepLog<StepLogKind.SET, ChangedVariables<any>>;
+export type SetStepLog = BaseStepLog<StepLogKind.SET, PathReference & ChangedVariables<any>>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/speak.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/speak.ts
@@ -1,9 +1,11 @@
+import { PathReference } from '@base-types/runtimeLogs/utils';
+
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
 export type SpeakStepLog = BaseStepLog<
   StepLogKind.SPEAK,
-  {
+  (PathReference | Record<keyof PathReference, null>) & {
     text: string;
   }
 >;

--- a/packages/base-types/src/runtimeLogs/logs/steps/start.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/start.ts
@@ -1,7 +1,7 @@
+import { PathReference } from '@base-types/runtimeLogs/utils';
 import { EmptyObject } from '@voiceflow/common';
 
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
-// TODO: Consider including information from the global.conversation_start event here
-export type StartStepLog = BaseStepLog<StepLogKind.START, EmptyObject>;
+export type StartStepLog = BaseStepLog<StepLogKind.START, PathReference | EmptyObject>;

--- a/packages/base-types/src/runtimeLogs/logs/steps/text.ts
+++ b/packages/base-types/src/runtimeLogs/logs/steps/text.ts
@@ -1,11 +1,12 @@
 import { Text as TextNode } from '@base-types/node';
+import { PathReference } from '@base-types/runtimeLogs/utils';
 
 import { BaseStepLog } from '../base';
 import { StepLogKind } from '../kinds';
 
 export type TextStepLog = BaseStepLog<
   StepLogKind.TEXT,
-  {
+  (PathReference | Record<keyof PathReference, null>) & {
     plainContent: string;
     richContent: TextNode.TextData;
   }


### PR DESCRIPTION
**Fixes or implements VF-4103**

### Brief description. What is this change?

the node (`PathReference`) can be nullable when a speak or text log is emitted by something that isn't a standard step (ex. prompt step)

### Related PRs

- https://github.com/voiceflow/general-runtime/pull/381

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written