### PR TITLE
[Merged by Bors] - fix: reference types in published directory (VF-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@voiceflow/eslint-config": "6.1.0",
     "@voiceflow/git-branch-check": "1.4.0",
     "@voiceflow/prettier-config": "1.2.1",
-    "@voiceflow/tsconfig": "1.4.4",
+    "@voiceflow/tsconfig": "1.4.5",
     "@zerollup/ts-transform-paths": "^1.7.18",
     "chai": "4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/packages/alexa-types/package.json
+++ b/packages/alexa-types/package.json
@@ -46,5 +46,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/alexa-types/package.json
+++ b/packages/alexa-types/package.json
@@ -46,5 +46,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -52,5 +52,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config ./config/tests/.mocharc.json",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config ./config/tests/.mocharc.json 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -52,5 +52,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config ./config/tests/.mocharc.json",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config ./config/tests/.mocharc.json 'tests/**/*.unit.ts'"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/base-types/package.json
+++ b/packages/base-types/package.json
@@ -44,5 +44,5 @@
     "test:smoke": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/base-types/package.json
+++ b/packages/base-types/package.json
@@ -44,5 +44,5 @@
     "test:smoke": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -43,5 +43,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -43,5 +43,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -59,5 +59,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -59,5 +59,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/google-dfes-types/package.json
+++ b/packages/google-dfes-types/package.json
@@ -47,5 +47,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/google-dfes-types/package.json
+++ b/packages/google-dfes-types/package.json
@@ -47,5 +47,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/google-types/package.json
+++ b/packages/google-types/package.json
@@ -47,5 +47,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/google-types/package.json
+++ b/packages/google-types/package.json
@@ -47,5 +47,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -55,5 +55,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/index.d.ts"
 }

--- a/packages/nestjs-common/package.json
+++ b/packages/nestjs-common/package.json
@@ -53,5 +53,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/index.d.ts"
 }

--- a/packages/nestjs-metrics/package.json
+++ b/packages/nestjs-metrics/package.json
@@ -61,5 +61,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/index.d.ts"
 }

--- a/packages/nestjs-mongodb/package.json
+++ b/packages/nestjs-mongodb/package.json
@@ -60,5 +60,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/index.d.ts"
 }

--- a/packages/nestjs-rate-limit/package.json
+++ b/packages/nestjs-rate-limit/package.json
@@ -61,5 +61,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/index.d.ts"
 }

--- a/packages/nestjs-redis/package.json
+++ b/packages/nestjs-redis/package.json
@@ -61,5 +61,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/index.d.ts"
 }

--- a/packages/nestjs-timeout/package.json
+++ b/packages/nestjs-timeout/package.json
@@ -56,5 +56,5 @@
     "test:single": "NODE_ENV=test ts-mocha --paths --config config/tests/mocharc.yml",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --config config/tests/mocharc.yml 'tests/**/*.unit.ts'"
   },
-  "types": "src/index.ts"
+  "types": "build/index.d.ts"
 }

--- a/packages/voice-types/package.json
+++ b/packages/voice-types/package.json
@@ -43,5 +43,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/voice-types/package.json
+++ b/packages/voice-types/package.json
@@ -43,5 +43,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/packages/voiceflow-types/package.json
+++ b/packages/voiceflow-types/package.json
@@ -44,5 +44,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "build/esm/index.d.ts"
+  "types": "build/cjs/index.d.ts"
 }

--- a/packages/voiceflow-types/package.json
+++ b/packages/voiceflow-types/package.json
@@ -44,5 +44,5 @@
     "test:integration": "exit 0",
     "test:unit": "exit 0"
   },
-  "types": "src/index.ts"
+  "types": "build/esm/index.d.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,10 +1963,10 @@
   resolved "https://registry.yarnpkg.com/@voiceflow/prettier-config/-/prettier-config-1.2.1.tgz#906bc852bcd8b2586fa62e4635392a0bea1fdb59"
   integrity sha512-J7wnJCwRWSNX33Ji2eLeBxtwXplAKIk9/aOfrHVfKmYrLHqXvOcrl2/7xa37jqnuTl8vw3+UsfFo3sMDY6weTg==
 
-"@voiceflow/tsconfig@1.4.4":
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/@voiceflow/tsconfig/-/tsconfig-1.4.4.tgz#0d55a701f47c07d1b7576255fadb06347e01adfb"
-  integrity sha512-gfPtPOkkcUF2QvTjRral1PWN6VZLwqxQGEx6SJ23RxkxfLdEjQh1aRxRZBDO/yLyogYmnevOgBIbGjMMlmxbtg==
+"@voiceflow/tsconfig@1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@voiceflow/tsconfig/-/tsconfig-1.4.5.tgz#38c1f9df6e1fe8c45e50ffd4e8408c015d0deb3e"
+  integrity sha512-ndeA7Gn272JshpLs7ZmgtuIbdjIjomjJ4vKgw4B5iYlDnghuMIPPqOaocPsf2ajTy/LavJeAYhA4mDY/ZCO9GA==
   dependencies:
     "@zerollup/ts-transform-paths" "1.7.18"
     "@zoltu/typescript-transformer-append-js-extension" "1.0.1"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

The `package.json` includes a `files` property that is used to say what is included in the published tarball. These all reference the `build` directory: the output of the typescript compiler.
There is also a `types` property that is used to tell typescript where the types are located for that package. These were referencing the `src` directory, which is not included in the published package. Therefore typescript could not find types, since they reference to them didn't exist.

Depends on: https://github.com/voiceflow/tsconfig/pull/30