### PR TITLE
[Merged by Bors] - fix: do not use js ext plugin (vf-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@voiceflow/eslint-config": "6.1.0",
     "@voiceflow/git-branch-check": "1.4.0",
     "@voiceflow/prettier-config": "1.2.1",
-    "@voiceflow/tsconfig": "1.4.5",
+    "@voiceflow/tsconfig": "1.4.6",
     "@zerollup/ts-transform-paths": "^1.7.18",
     "chai": "4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,13 +1963,12 @@
   resolved "https://registry.yarnpkg.com/@voiceflow/prettier-config/-/prettier-config-1.2.1.tgz#906bc852bcd8b2586fa62e4635392a0bea1fdb59"
   integrity sha512-J7wnJCwRWSNX33Ji2eLeBxtwXplAKIk9/aOfrHVfKmYrLHqXvOcrl2/7xa37jqnuTl8vw3+UsfFo3sMDY6weTg==
 
-"@voiceflow/tsconfig@1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@voiceflow/tsconfig/-/tsconfig-1.4.5.tgz#38c1f9df6e1fe8c45e50ffd4e8408c015d0deb3e"
-  integrity sha512-ndeA7Gn272JshpLs7ZmgtuIbdjIjomjJ4vKgw4B5iYlDnghuMIPPqOaocPsf2ajTy/LavJeAYhA4mDY/ZCO9GA==
+"@voiceflow/tsconfig@1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@voiceflow/tsconfig/-/tsconfig-1.4.6.tgz#66cb73236aaf853ac6afcccc6570fc9bd64985b7"
+  integrity sha512-jPT8DEc4Nr+8CK4fb/Fh52B+OQzhg1ObDclk5YWFCNuFhjhi+XeSRG0H3vSnr0EfM/At1yO9+939VEr3PKn3Zw==
   dependencies:
     "@zerollup/ts-transform-paths" "1.7.18"
-    "@zoltu/typescript-transformer-append-js-extension" "1.0.1"
     typescript-transform-paths "3.3.1"
 
 "@vue/compiler-core@3.2.30":
@@ -2043,11 +2042,6 @@
   integrity sha512-YPVUxvWQVzRx1OBN0Pmkd58+R9FcfUJuwTaPUSoi5rKxuXMtxevTXdfi0w5mEaIH8b0DfL+wg0wFDHiJE+S2zA==
   dependencies:
     "@zerollup/ts-helpers" "^1.7.18"
-
-"@zoltu/typescript-transformer-append-js-extension@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@zoltu/typescript-transformer-append-js-extension/-/typescript-transformer-append-js-extension-1.0.1.tgz#c7edaccaef0fc87c0c85d6ce4f074e66a42d9080"
-  integrity sha512-7Lp30MtJO7YHZW19yJWhkuJrf+Y78COHopeZli7fiWrbIRvodsSXZIa7cFX/c4PFwFJt55N/7Pp/t6VH0fwBVQ==
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
Use latest `@voiceflow/tsconfig` to avoid adding `.js` suffixes to built ESM modules
https://voiceflowhq.slack.com/archives/CCF7MAGC8/p1658330904889699?thread_ts=1658257372.276349&cid=CCF7MAGC8