### PR TITLE
[Merged by Bors] - fix: update BlockTemplate types to use diagramID instead of new structure (CT-679)

### DIFF
--- a/packages/base-types/src/models/diagram.ts
+++ b/packages/base-types/src/models/diagram.ts
@@ -4,6 +4,7 @@ export enum DiagramType {
   TOPIC = 'TOPIC',
   GROUP = 'GROUP',
   COMPONENT = 'COMPONENT',
+  TEMPLATE = 'TEMPLATE',
 }
 
 export interface Model<Node extends BaseDiagramNode = BaseDiagramNode> {

--- a/packages/base-types/src/models/version/blockTemplate.ts
+++ b/packages/base-types/src/models/version/blockTemplate.ts
@@ -1,7 +1,0 @@
-import { BaseDiagramNode } from '../base';
-
-export interface BlockTemplate {
-  name: string;
-  color: string;
-  template: BaseDiagramNode[];
-}

--- a/packages/base-types/src/models/version/canvasTemplate.ts
+++ b/packages/base-types/src/models/version/canvasTemplate.ts
@@ -1,0 +1,6 @@
+export interface CanvasTemplate {
+  id: string;
+  name: string;
+  color: string;
+  nodeIDs: string[];
+}

--- a/packages/base-types/src/models/version/index.ts
+++ b/packages/base-types/src/models/version/index.ts
@@ -1,10 +1,10 @@
 import { AnyRecord } from '@voiceflow/common';
 
 import { BaseCommand, BaseNote, Intent, Slot, Variable } from '../base';
-import { BlockTemplate } from './blockTemplate';
+import { CanvasTemplate } from './canvasTemplate';
 import { Prototype } from './prototype';
 
-export * from './blockTemplate';
+export * from './canvasTemplate';
 export * from './prototype';
 
 export interface PlatformData<Settings extends AnyRecord = AnyRecord, Publishing extends AnyRecord = AnyRecord> {
@@ -62,7 +62,8 @@ export interface Model<_PlatformData extends PlatformData, Command extends BaseC
   prototype?: Prototype<Command, Locale>;
   components?: FolderItem[];
   platformData: _PlatformData;
-  blockTemplates?: BlockTemplate[];
+  canvasTemplates?: CanvasTemplate[];
+  templateDiagramID?: string;
 
   manualSave: boolean;
   autoSaveFromRestore: boolean;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-679**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

We decided to use diagram to save the templates. That will better support migrations and it will makes things easier if we decide to support edition of a template.
To support that, we introduced a new diagram type: TEMPLATE.
Also, version will only point out to a diagramID instead of saving the whole node inside it.
