### PR TITLE
[Merged by Bors] - feat: support to canvas templates on api-sdk (CT-000)

### DIFF
--- a/packages/api-sdk/src/resources/version/canvasTemplate.ts
+++ b/packages/api-sdk/src/resources/version/canvasTemplate.ts
@@ -1,0 +1,45 @@
+import Fetch from '@api-sdk/fetch';
+import { BaseModels } from '@voiceflow/base-types';
+
+import CrudNestedResource from '../crudNested';
+
+const ENDPOINT = 'canvasTemplate';
+
+export type ModelKey = 'id';
+
+class CanvasTemplateResource extends CrudNestedResource<string, BaseModels.Version.CanvasTemplate, ModelKey, CanvasTemplateResource> {
+  constructor(fetch: Fetch, { parentEndpoint }: { parentEndpoint: string }) {
+    super({
+      fetch,
+      clazz: CanvasTemplateResource,
+      endpoint: ENDPOINT,
+      clazzOptions: { parentEndpoint },
+    });
+  }
+
+  public async list(versionID: string): Promise<BaseModels.Version.CanvasTemplate[]> {
+    return this._get<BaseModels.Version.CanvasTemplate>(versionID);
+  }
+
+  public async get(versionID: string, id: string): Promise<BaseModels.Version.CanvasTemplate> {
+    return this._getByID<BaseModels.Version.CanvasTemplate>(versionID, id);
+  }
+
+  public async create(versionID: string, body: BaseModels.Version.CanvasTemplate): Promise<BaseModels.Version.CanvasTemplate> {
+    return this._post<BaseModels.Version.CanvasTemplate>(versionID, body);
+  }
+
+  public async update<T extends Partial<Omit<BaseModels.Version.CanvasTemplate, ModelKey | 'rootDiagramID'>>>(
+    versionID: string,
+    id: string,
+    body: T
+  ): Promise<T> {
+    return this._patch<T>(versionID, id, body);
+  }
+
+  public async delete(versionID: string, id: string): Promise<string> {
+    return this._delete(versionID, id);
+  }
+}
+
+export default CanvasTemplateResource;

--- a/packages/api-sdk/src/resources/version/index.ts
+++ b/packages/api-sdk/src/resources/version/index.ts
@@ -4,6 +4,7 @@ import { AnyRecord } from '@voiceflow/common';
 
 import { Fields } from '../base';
 import CrudResource from '../crud';
+import CanvasTemplate from './canvasTemplate';
 import Domain from './domain';
 
 export const ENDPOINT = 'versions';
@@ -13,6 +14,8 @@ export type ModelKey = '_id';
 class VersionResource extends CrudResource<BaseModels.Version.Model<BaseModels.Version.PlatformData>, ModelKey, VersionResource, 'creatorID'> {
   public domain: Domain;
 
+  public canvasTemplate: CanvasTemplate;
+
   constructor(fetch: Fetch) {
     super({
       fetch,
@@ -21,6 +24,7 @@ class VersionResource extends CrudResource<BaseModels.Version.Model<BaseModels.V
     });
 
     this.domain = new Domain(fetch, { parentEndpoint: ENDPOINT });
+    this.canvasTemplate = new CanvasTemplate(fetch, { parentEndpoint: ENDPOINT });
   }
 
   public async get<T extends Partial<BaseModels.Version.Model<BaseModels.Version.PlatformData>>>(id: string, fields: Fields): Promise<T>;

--- a/packages/api-sdk/tests/resources/version/canvasTemplate.unit.ts
+++ b/packages/api-sdk/tests/resources/version/canvasTemplate.unit.ts
@@ -1,0 +1,118 @@
+/* eslint-disable dot-notation */
+import CrudNested from '@api-sdk/resources/crudNested';
+import CanvasTemplate from '@api-sdk/resources/version/canvasTemplate';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+const RESPONSE_DATA = { field1: '1', field2: { subfield: [1, 10] } };
+
+const createClient = () => {
+  const fetch = {
+    get: sinon.stub(),
+    post: sinon.stub(),
+    put: sinon.stub(),
+    patch: sinon.stub(),
+    delete: sinon.stub(),
+  };
+
+  const crud = {
+    get: sinon.stub(),
+    getByID: sinon.stub(),
+    post: sinon.stub(),
+    put: sinon.stub(),
+    patch: sinon.stub(),
+    delete: sinon.stub(),
+  };
+
+  CrudNested.prototype['_get'] = crud.get;
+  CrudNested.prototype['_getByID'] = crud.getByID;
+  CrudNested.prototype['_post'] = crud.post;
+  CrudNested.prototype['_put'] = crud.put;
+  CrudNested.prototype['_patch'] = crud.patch;
+  CrudNested.prototype['_delete'] = crud.delete;
+
+  const resource = new CanvasTemplate(fetch as any, { parentEndpoint: 'parentEndpoint' });
+
+  return {
+    crud,
+    fetch,
+    resource,
+  };
+};
+
+describe('CanvasTemplateResource', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('.list', async () => {
+    const { crud, resource } = createClient();
+
+    crud.get.resolves(RESPONSE_DATA);
+
+    const data = await resource.list('version-id');
+
+    expect(crud.get.callCount).to.eql(1);
+    expect(crud.get.args[0]).to.eql(['version-id']);
+    expect(data).to.eql(RESPONSE_DATA);
+  });
+
+  it('.get', async () => {
+    const { crud, resource } = createClient();
+
+    crud.getByID.resolves(RESPONSE_DATA);
+
+    const data = await resource.get('version-id', '1');
+
+    expect(crud.getByID.callCount).to.eql(1);
+    expect(crud.getByID.args[0]).to.eql(['version-id', '1']);
+    expect(data).to.eql(RESPONSE_DATA);
+  });
+
+  it('.create', async () => {
+    const { crud, resource } = createClient();
+
+    crud.post.resolves(RESPONSE_DATA);
+
+    const body = {
+      id: '123',
+      name: 'name',
+      color: '#ff0000',
+      nodeIDs: [],
+    };
+
+    const data = await resource.create('version-id', body);
+
+    expect(crud.post.callCount).to.eql(1);
+    expect(crud.post.args[0]).to.eql(['version-id', body]);
+    expect(data).to.eql(RESPONSE_DATA);
+  });
+
+  it('.update', async () => {
+    const { crud, resource } = createClient();
+
+    crud.patch.resolves(RESPONSE_DATA);
+
+    const body = {
+      name: 'new',
+    };
+
+    const data = await resource.update('version-id', '1', body);
+
+    expect(crud.patch.callCount).to.eql(1);
+    expect(crud.patch.args[0]).to.eql(['version-id', '1', body]);
+    expect(data).to.eql(RESPONSE_DATA);
+  });
+
+  it('.delete', async () => {
+    const { crud, resource } = createClient();
+
+    crud.delete.resolves(RESPONSE_DATA);
+
+    const data = await resource.delete('version-id', '1');
+
+    expect(crud.delete.callCount).to.eql(1);
+    expect(crud.delete.args[0]).to.eql(['version-id', '1']);
+    expect(data).to.eql(RESPONSE_DATA);
+  });
+});


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-000**

### Brief description. What is this change?
 - In order to use canvas templates endpoints on realtime, we need to include them to api-sdk

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/creator-api/pull/1046

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x ] appropriate tests have been written
