### PR TITLE
fix: cleanup ports types (CT-791)

### DIFF
--- a/packages/base-types/src/node/_v1.ts
+++ b/packages/base-types/src/node/_v1.ts
@@ -1,6 +1,6 @@
 import { Nullable } from '@voiceflow/common';
 
-import { BaseEvent, BaseNode, BaseStep, NodeID } from './utils';
+import { BaseEvent, BaseNode, BaseStep, DynamicOnlyStepPorts, NodeID } from './utils';
 
 export const _V1_STOP_TYPES = 'stopTypes';
 
@@ -12,7 +12,9 @@ export interface StepData<Payload = unknown> {
   defaultPath?: number;
 }
 
-export interface Step<Payload = unknown> extends BaseStep<StepData<Payload>> {
+export interface StepPorts extends DynamicOnlyStepPorts {}
+
+export interface Step<Payload = unknown> extends BaseStep<StepData<Payload>, StepPorts> {
   type: string;
 }
 

--- a/packages/base-types/src/node/_v1.ts
+++ b/packages/base-types/src/node/_v1.ts
@@ -1,6 +1,6 @@
 import { Nullable } from '@voiceflow/common';
 
-import { BaseEvent, BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeID } from './utils';
+import { BaseEvent, BaseNode, BaseStep, NodeID } from './utils';
 
 export const _V1_STOP_TYPES = 'stopTypes';
 
@@ -12,13 +12,7 @@ export interface StepData<Payload = unknown> {
   defaultPath?: number;
 }
 
-export interface StepPort<Event = BaseEvent> extends BasePort {
-  data: { event?: Event };
-}
-
-export interface StepPorts<Event> extends BaseStepPorts<Record<string, StepPort<Event>>, StepPort<Event>[]> {}
-
-export interface Step<Payload = unknown, Event = BaseEvent> extends BaseStep<StepData<Payload>, StepPorts<Event>, BasePortList<StepPort<Event>>> {
+export interface Step<Payload = unknown> extends BaseStep<StepData<Payload>> {
   type: string;
 }
 

--- a/packages/base-types/src/node/channelAction.ts
+++ b/packages/base-types/src/node/channelAction.ts
@@ -1,23 +1,7 @@
 import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
-import { BaseEvent, BaseNode, BasePort, BasePortList, BaseStep, BaseStepPorts, NodeID } from './utils';
-
-interface StepData<Payload = unknown> {
-  stop?: boolean;
-  payload: Payload;
-  defaultPath?: number;
-}
-
-export interface StepPort<Event = BaseEvent> extends BasePort {
-  data: { event?: Event };
-}
-
-interface StepPorts<Event> extends BaseStepPorts<Record<string, StepPort<Event>>, StepPort<Event>[]> {}
-
-export interface Step<Payload = unknown, Event = BaseEvent> extends BaseStep<StepData<Payload>, StepPorts<Event>, BasePortList<StepPort<Event>>> {
-  type: NodeType.CHANNEL_ACTION;
-}
+import { BaseEvent, BaseNode, NodeID } from './utils';
 
 interface NodePath<Event = BaseEvent> {
   label?: string;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-791**

### Brief description. What is this change?
We should no longer extend ports with extra data anywhere. Confirmed with @pmvrmc that channelAction steps are not needed
