### PR TITLE
[Merged by Bors] - fix: utterance replacer (PL-000)

### DIFF
--- a/packages/common/src/utils/intent.ts
+++ b/packages/common/src/utils/intent.ts
@@ -78,12 +78,18 @@ const continuousReplace = (text: string, regex: RegExp, replacer: (substring: st
   return current;
 };
 
-export const utteranceEntityPermutations = (
-  utterances: string[],
-  entitiesByID: Record<string, { inputs: string[]; name: string }>,
-  limit = 22
+export const utteranceEntityPermutations = ({
+  utterances,
+  entitiesByID,
+  limit = 22,
+  replacer,
+}: {
+  utterances: string[];
+  entitiesByID: Record<string, { inputs: string[]; name: string }>;
+  limit?: number;
+  replacer?: (sample: string, entityID: string) => string;
   // eslint-disable-next-line sonarjs/cognitive-complexity
-): JSONUtterance[] => {
+}): JSONUtterance[] => {
   const newUtterances: JSONUtterance[] = [];
   const entityRef: Record<string, { utterances: string[]; samples: string[] }> = {};
 
@@ -100,17 +106,19 @@ export const utteranceEntityPermutations = (
       const sample = (entityRef[entityID]?.samples.shift() || _sample(getAllSamples(entity?.inputs)) || entityName).trim();
       if (!entityRef[entityID]?.samples?.length) delete entityRef[entityID];
 
+      const replacement = replacer?.(sample, entityID) ?? sample;
+
       // This module should additionally create one full training utterance with positional entity (startPos, endPos, entityName).
       const startPos = offset || 0;
-      const endPos = startPos + sample.length - 1;
+      const endPos = startPos + replacement.length - 1;
       entities.push({
         startPos,
         endPos,
         entity: entity.name,
       });
 
-      // Replace the entities with the sample value
-      return sample;
+      // Replace the entities with the replacement value
+      return replacement;
     });
 
     newUtterances.push({

--- a/packages/common/src/utils/intent.ts
+++ b/packages/common/src/utils/intent.ts
@@ -83,11 +83,13 @@ export const utteranceEntityPermutations = ({
   entitiesByID,
   limit = 22,
   replacer,
+  getSamples = getAllSamples,
 }: {
   utterances: string[];
   entitiesByID: Record<string, { inputs: string[]; name: string }>;
   limit?: number;
   replacer?: (sample: string, entityID: string) => string;
+  getSamples: (inputs: string[]) => string[];
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }): JSONUtterance[] => {
   const newUtterances: JSONUtterance[] = [];
@@ -103,7 +105,7 @@ export const utteranceEntityPermutations = ({
       const entity = entitiesByID[entityID];
       if (!entity) return entityName;
 
-      const sample = (entityRef[entityID]?.samples.shift() || _sample(getAllSamples(entity?.inputs)) || entityName).trim();
+      const sample = (entityRef[entityID]?.samples.shift() || _sample(getSamples(entity?.inputs)) || entityName).trim();
       if (!entityRef[entityID]?.samples?.length) delete entityRef[entityID];
 
       const replacement = replacer?.(sample, entityID) ?? sample;
@@ -139,7 +141,7 @@ export const utteranceEntityPermutations = ({
         entityRef[entityID] = { samples: [], utterances: [] };
         const entity = entitiesByID[entityID];
         if (entity) {
-          entityRef[entityID].samples.push(...getAllSamples(entity.inputs));
+          entityRef[entityID].samples.push(...getSamples(entity.inputs));
         }
       }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-000**

### Brief description. What is this change?
Let's look at utterances like this:
`connect to {{[network].4i3h3mmi}} wifi on my own'`
`steps to connect to {{[network].4i3h3mmi}} wifi for {{[device].xdfh3gkl}}`

So currently `utteranceEntityPermutations` generates something like this:
```
  {
    text: 'connect to guest wifi on my own',
    entities: [
      { startPos: 10, endPos: 15, entity: 'network' },
    ]
  },
  {
    text: 'steps to connect to guest wifi for android',
    entities: [
      { startPos: 20, endPos: 24, entity: 'network' },
      { startPos: 35, endPos: 41, entity: 'device' }
    ]
  }
```

which is very useful for LUIS but not for many other NLPs.

Rasa expects something that looks like this:
```
      - connect to [guest](network_type) wifi on my [android](device)
```

I don't want to create another algo that injects back into the string. So I added a optional replacer modifer :)

The tests should make it clear what the replacer is doing