### PR TITLE
[Merged by Bors] - fix: add optional platform data to nodes (PL-000)

### DIFF
--- a/packages/base-types/src/node/buttons.ts
+++ b/packages/base-types/src/node/buttons.ts
@@ -44,4 +44,5 @@ export interface StepPorts extends NoMatchNoReplyStepPorts {}
 
 export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.BUTTONS;
+  platform?: string;
 }

--- a/packages/base-types/src/node/capture.ts
+++ b/packages/base-types/src/node/capture.ts
@@ -35,4 +35,5 @@ export interface Node extends BaseNode, NodeNextID, BaseNoReplyNodeData {
   intent?: string;
   slots?: string[];
   variable: string;
+  platform?: string;
 }

--- a/packages/base-types/src/node/captureV2.ts
+++ b/packages/base-types/src/node/captureV2.ts
@@ -55,4 +55,5 @@ export interface Node extends BaseNode, NodeNextID, NodeIntentScope, BaseNoReply
   type: NodeType.CAPTURE_V2;
   intent?: NodeIntent;
   variable?: string;
+  platform?: string;
 }

--- a/packages/base-types/src/node/carousel.ts
+++ b/packages/base-types/src/node/carousel.ts
@@ -55,6 +55,7 @@ export interface Node extends BaseNode, NodeNextID, BaseNoReplyNodeData, BaseNoM
   cards: NodeCarouselCard[];
   layout: CarouselLayout;
   isBlocking: boolean;
+  platform?: string;
 }
 
 export interface TraceCarouselCardDescription {

--- a/packages/base-types/src/node/channelAction.ts
+++ b/packages/base-types/src/node/channelAction.ts
@@ -34,4 +34,5 @@ export interface Node<Event = BaseEvent> extends BaseNode {
   stop: boolean;
   defaultPath?: number; // index starting from 0
   paths: Array<NodePath<Event>>;
+  platform?: string;
 }

--- a/packages/base-types/src/node/goTo.ts
+++ b/packages/base-types/src/node/goTo.ts
@@ -16,4 +16,5 @@ export interface Step<Data = StepData> extends BaseStep<Data, EmptyObject, []> {
 export interface Node extends BaseNode, BaseNoMatchNodeData {
   type: NodeType.GOTO;
   request: IntentRequest;
+  platform?: string;
 }

--- a/packages/base-types/src/node/interaction.ts
+++ b/packages/base-types/src/node/interaction.ts
@@ -73,6 +73,7 @@ export interface NodeInteraction<Event = BaseEvent> extends NodeNextID {
 export interface Node<Event = BaseEvent> extends BaseNode, DeprecatedBaseNodeNoMatch, BaseNoReplyNodeData, NodeIntentScope, BaseNoMatchNodeData {
   type: NodeType.INTERACTION;
   interactions: NodeInteraction<Event>[];
+  platform?: string;
 }
 
 export interface TraceFramePayload {

--- a/packages/base-types/src/node/jump.ts
+++ b/packages/base-types/src/node/jump.ts
@@ -27,4 +27,5 @@ export interface Command extends BaseCommand, Required<SlotMappings> {
   next: NodeID;
   intent: string;
   diagramID?: string;
+  platform?: string;
 }

--- a/packages/base-types/src/node/push.ts
+++ b/packages/base-types/src/node/push.ts
@@ -23,4 +23,5 @@ export interface Command extends BaseCommand, Required<SlotMappings> {
   next?: NodeID;
   intent: string;
   diagram_id?: string;
+  platform?: string;
 }

--- a/packages/base-types/src/node/stream.ts
+++ b/packages/base-types/src/node/stream.ts
@@ -58,4 +58,5 @@ export interface TraceFramePayload {
 
 export interface TraceFrame extends BaseTraceFrame<TraceFramePayload> {
   type: TraceType.STREAM;
+  platform?: string;
 }

--- a/packages/base-types/src/node/text.ts
+++ b/packages/base-types/src/node/text.ts
@@ -19,6 +19,7 @@ export interface Step<Data = StepData> extends BaseStep<Data> {
 export interface Node extends BaseNode, NodeNextID {
   type: NodeType.TEXT;
   texts: TextData[];
+  platform?: string;
 }
 
 export interface TextTracePayload {

--- a/packages/base-types/src/node/visual.ts
+++ b/packages/base-types/src/node/visual.ts
@@ -88,6 +88,7 @@ export interface Step<Data = StepData> extends BaseStep<Data> {
 export interface Node extends BaseNode, NodeNextID {
   type: NodeType.VISUAL;
   data: StepData;
+  platform?: string;
 }
 
 export interface TraceFrame extends BaseTraceFrame<StepData> {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-000**

### Brief description. What is this change?
I noticed in https://github.com/voiceflow/general-service/pull/384 we were casting many nodes:
`} as GoogleNode.Capture.Node;`
`} as GoogleNode.Interaction.Node;`

using `as` is usual not the best pattern and we should want to define the type so everything is expected.

I looked everywhere where we write `platform: context.platform,`
