### PR TITLE
[Merged by Bors] - feat: no match no reply prompt types

### DIFF
--- a/packages/chat-types/src/node/utils.ts
+++ b/packages/chat-types/src/node/utils.ts
@@ -1,5 +1,5 @@
 import { Prompt } from '@chat-types/models';
-import { BaseNode, BaseText, Nullable } from '@voiceflow/base-types';
+import { BaseNode, BaseText } from '@voiceflow/base-types';
 
 export interface StepNoReply extends BaseNode.Utils.StepNoReply<Prompt> {}
 
@@ -25,11 +25,3 @@ export interface NodeReprompt extends BaseNode.Utils.NodeReprompt<BaseText.Slate
  * @deprecated use NodeNoMatch instead
  */
 export interface DeprecatedNodeNoMatch extends BaseNode.Utils.DeprecatedNodeNoMatch<BaseText.SlateTextValue> {}
-
-export interface NoMatchNode extends BaseNode.Utils.BaseNode, DeprecatedNodeNoMatch {
-  noMatch?: Nullable<NodeNoMatch>;
-}
-
-export interface NoReplyNode extends BaseNode.Utils.BaseNode, NodeReprompt {
-  noReply?: Nullable<NodeNoReply>;
-}

--- a/packages/voice-types/src/node/utils.ts
+++ b/packages/voice-types/src/node/utils.ts
@@ -1,5 +1,5 @@
 import { Prompt } from '@voice-types/models';
-import { BaseNode, Nullable } from '@voiceflow/base-types';
+import { BaseNode } from '@voiceflow/base-types';
 
 export interface StepNoReply<Voice> extends BaseNode.Utils.StepNoReply<Prompt<Voice>> {}
 
@@ -25,11 +25,3 @@ export interface NodeReprompt extends BaseNode.Utils.NodeReprompt<string> {}
  * @deprecated use NodeNoMatch instead
  */
 export interface DeprecatedNodeNoMatch extends BaseNode.Utils.DeprecatedNodeNoMatch<string> {}
-
-export interface NoMatchNode extends BaseNode.Utils.BaseNode, DeprecatedNodeNoMatch {
-  noMatch?: Nullable<NodeNoMatch>;
-}
-
-export interface NoReplyNode extends BaseNode.Utils.BaseNode, NodeReprompt {
-  noReply?: Nullable<NodeNoReply>;
-}

--- a/packages/voiceflow-types/src/node/capture/chat.ts
+++ b/packages/voiceflow-types/src/node/capture/chat.ts
@@ -5,6 +5,3 @@ export interface ChatStepData extends ChatNode.Capture.StepData {}
 
 /** @deprecated */
 export interface ChatStep extends ChatNode.Capture.Step<ChatStepData> {}
-
-/** @deprecated */
-export interface ChatNode extends ChatNode.Capture.Node {}

--- a/packages/voiceflow-types/src/node/capture/index.ts
+++ b/packages/voiceflow-types/src/node/capture/index.ts
@@ -1,7 +1,8 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, BaseRequest } from '@voiceflow/base-types';
 
-import { ChatNode, ChatStep, ChatStepData } from './chat';
-import { VoiceNode, VoiceStep, VoiceStepData } from './voice';
+import { VoiceflowPrompt } from '../utils';
+import { ChatStep, ChatStepData } from './chat';
+import { VoiceStep, VoiceStepData } from './voice';
 
 export * from './chat';
 export * from './voice';
@@ -16,4 +17,6 @@ export type StepPorts = BaseNode.Capture.StepPorts;
 export type StepData = ChatStepData | VoiceStepData;
 
 /** @deprecated */
-export type Node = ChatNode | VoiceNode;
+export interface Node extends BaseNode.Capture.Node, BaseRequest.NodeButton {
+  noReply?: BaseNode.Utils.NodeNoReply<VoiceflowPrompt> | null;
+}

--- a/packages/voiceflow-types/src/node/capture/voice.ts
+++ b/packages/voiceflow-types/src/node/capture/voice.ts
@@ -1,4 +1,4 @@
-import { BaseButton, BaseRequest } from '@voiceflow/base-types';
+import { BaseButton } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
 import { Voice } from '@voiceflow-types/constants';
 
@@ -7,6 +7,3 @@ export interface VoiceStepData extends VoiceNode.Capture.StepData<Voice>, BaseBu
 
 /** @deprecated */
 export interface VoiceStep extends VoiceNode.Capture.Step<VoiceStepData> {}
-
-/** @deprecated */
-export interface VoiceNode extends VoiceNode.Capture.Node, BaseRequest.NodeButton {}

--- a/packages/voiceflow-types/src/node/captureV2/chat.ts
+++ b/packages/voiceflow-types/src/node/captureV2/chat.ts
@@ -1,8 +1,6 @@
-import { BaseButton, BaseRequest } from '@voiceflow/base-types';
+import { BaseButton } from '@voiceflow/base-types';
 import { ChatNode } from '@voiceflow/chat-types';
 
 export interface ChatStepData extends ChatNode.CaptureV2.StepData, BaseButton.StepButton {}
 
 export interface ChatStep extends ChatNode.CaptureV2.Step<ChatStepData> {}
-
-export interface ChatNode extends ChatNode.CaptureV2.Node, BaseRequest.NodeButton {}

--- a/packages/voiceflow-types/src/node/captureV2/index.ts
+++ b/packages/voiceflow-types/src/node/captureV2/index.ts
@@ -1,7 +1,8 @@
 import { BaseNode } from '@voiceflow/base-types';
 
-import { ChatNode, ChatStep, ChatStepData } from './chat';
-import { VoiceNode, VoiceStep, VoiceStepData } from './voice';
+import { VoiceflowPrompt } from '../utils';
+import { ChatStep, ChatStepData } from './chat';
+import { VoiceStep, VoiceStepData } from './voice';
 
 export * from './chat';
 export * from './voice';
@@ -12,4 +13,7 @@ export type StepPorts = BaseNode.CaptureV2.StepPorts;
 
 export type StepData = ChatStepData | VoiceStepData;
 
-export type Node = ChatNode | VoiceNode;
+export interface Node extends BaseNode.CaptureV2.Node {
+  noMatch?: BaseNode.Utils.NodeNoMatch<VoiceflowPrompt> | null;
+  noReply?: BaseNode.Utils.NodeNoReply<VoiceflowPrompt> | null;
+}

--- a/packages/voiceflow-types/src/node/captureV2/voice.ts
+++ b/packages/voiceflow-types/src/node/captureV2/voice.ts
@@ -1,9 +1,7 @@
-import { BaseButton, BaseRequest } from '@voiceflow/base-types';
+import { BaseButton } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
 import { Voice } from '@voiceflow-types/constants';
 
 export interface VoiceStepData extends VoiceNode.CaptureV2.StepData<Voice>, BaseButton.StepButton {}
 
 export interface VoiceStep extends VoiceNode.CaptureV2.Step<VoiceStepData> {}
-
-export interface VoiceNode extends VoiceNode.CaptureV2.Node, BaseRequest.NodeButton {}

--- a/packages/voiceflow-types/src/node/carousel/chat.ts
+++ b/packages/voiceflow-types/src/node/carousel/chat.ts
@@ -3,5 +3,3 @@ import { ChatNode } from '@voiceflow/chat-types';
 export interface ChatStepData extends ChatNode.Carousel.StepData {}
 
 export interface ChatStep extends ChatNode.Carousel.Step<ChatStepData> {}
-
-export interface ChatNode extends ChatNode.Carousel.Node {}

--- a/packages/voiceflow-types/src/node/carousel/index.ts
+++ b/packages/voiceflow-types/src/node/carousel/index.ts
@@ -1,6 +1,7 @@
 import { BaseNode } from '@voiceflow/base-types';
 
-import { ChatNode, ChatStep, ChatStepData } from './chat';
+import { VoiceflowPrompt } from '../utils';
+import { ChatStep, ChatStepData } from './chat';
 
 export * from './chat';
 
@@ -10,4 +11,7 @@ export type StepPorts = BaseNode.Carousel.StepPorts;
 
 export type StepData = ChatStepData;
 
-export type Node = ChatNode;
+export interface Node extends BaseNode.Carousel.Node {
+  noMatch?: BaseNode.Utils.NodeNoMatch<VoiceflowPrompt> | null;
+  noReply?: BaseNode.Utils.NodeNoReply<VoiceflowPrompt> | null;
+}

--- a/packages/voiceflow-types/src/node/index.ts
+++ b/packages/voiceflow-types/src/node/index.ts
@@ -17,6 +17,7 @@ export * as Carousel from './carousel';
 export * as Interaction from './interaction';
 export * as Prompt from './prompt';
 export * as Speak from './speak';
+export * as Utils from './utils';
 
 export type AnyExtendedStep =
   | Speak.Step

--- a/packages/voiceflow-types/src/node/interaction/chat.ts
+++ b/packages/voiceflow-types/src/node/interaction/chat.ts
@@ -1,8 +1,5 @@
-import { BaseNode } from '@voiceflow/base-types';
 import { ChatNode } from '@voiceflow/chat-types';
 
 export interface ChatStepData extends ChatNode.Interaction.StepData {}
 
 export interface ChatStep extends ChatNode.Interaction.Step<ChatStepData> {}
-
-export interface ChatNode<Event = BaseNode.Utils.BaseEvent> extends ChatNode.Interaction.Node<Event> {}

--- a/packages/voiceflow-types/src/node/interaction/index.ts
+++ b/packages/voiceflow-types/src/node/interaction/index.ts
@@ -1,7 +1,8 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, BaseRequest } from '@voiceflow/base-types';
 
-import { ChatNode, ChatStep, ChatStepData } from './chat';
-import { VoiceNode, VoiceStep, VoiceStepData } from './voice';
+import { VoiceflowPrompt } from '../utils';
+import { ChatStep, ChatStepData } from './chat';
+import { VoiceStep, VoiceStepData } from './voice';
 
 export * from './chat';
 export * from './voice';
@@ -12,4 +13,7 @@ export type StepPorts = BaseNode.Interaction.StepPorts;
 
 export type StepData = ChatStepData | VoiceStepData;
 
-export type Node = ChatNode | VoiceNode;
+export interface Node<Event = BaseNode.Utils.BaseEvent> extends BaseNode.Interaction.Node<Event>, BaseRequest.NodeButton {
+  noMatch?: BaseNode.Utils.NodeNoMatch<VoiceflowPrompt> | null;
+  noReply?: BaseNode.Utils.NodeNoReply<VoiceflowPrompt> | null;
+}

--- a/packages/voiceflow-types/src/node/interaction/voice.ts
+++ b/packages/voiceflow-types/src/node/interaction/voice.ts
@@ -1,9 +1,7 @@
-import { BaseButton, BaseNode, BaseRequest } from '@voiceflow/base-types';
+import { BaseButton } from '@voiceflow/base-types';
 import { VoiceNode } from '@voiceflow/voice-types';
 import { Voice } from '@voiceflow-types/constants';
 
 export interface VoiceStepData extends VoiceNode.Interaction.StepData<Voice>, BaseButton.StepButton {}
 
 export interface VoiceStep extends VoiceNode.Interaction.Step<VoiceStepData> {}
-
-export interface VoiceNode<Event = BaseNode.Utils.BaseEvent> extends VoiceNode.Interaction.Node<Event>, BaseRequest.NodeButton {}

--- a/packages/voiceflow-types/src/node/utils.ts
+++ b/packages/voiceflow-types/src/node/utils.ts
@@ -1,0 +1,11 @@
+import { BaseNode, BaseText } from '@voiceflow/base-types';
+
+export type VoiceflowPrompt = BaseText.SlateTextValue | string;
+
+export interface NoMatchNode extends BaseNode.Utils.BaseNode, BaseNode.Utils.DeprecatedNodeNoMatch<VoiceflowPrompt> {
+  noMatch?: BaseNode.Utils.NodeNoMatch<VoiceflowPrompt> | null;
+}
+
+export interface NoReplyNode extends BaseNode.Utils.BaseNode, BaseNode.Utils.NodeReprompt<VoiceflowPrompt> {
+  noReply?: BaseNode.Utils.NodeNoReply<VoiceflowPrompt> | null;
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-000**

### Brief description. What is this change?
THIS PR ONLY APPLIES TO PROGRAMS + NODES. It does not affect `creator-app`, blocks, steps, in any meaningful way.

Right now all `VoiceflowNodes` with `noMatch` or `noReply` depend on `ChatNode` and `VoiceNode`

This causes a ton of frustrating type issues on the compilers where today we just give up and cast it:
https://github.com/voiceflow/general-service/blob/master/lib/clients/platform/handlers/captureV2/compiler.ts#L34
https://github.com/voiceflow/general-service/blob/master/lib/clients/platform/handlers/interaction/compiler.ts#L91

Today, `VoiceflowNode.Interaction.Node` is actually `ChatNode.Interaction.Node | VoiceNode.Interaction.Node`, which each has distinctive properties for `noMatch` and `noReply`. It's hard for Typescript to resolve:
`NodeNoReply<string> | NodeNoReply<SlateTextValue>` vs `NodeNoReply<string | SlateTextValue>`

I think this new data format is more realistic because on `general-runtime` we don't care what the overall node is, just what type `noMatch` or `noReply` is. We're also going to be adding a `Voice + Chat` project type, so you might have chat and voice prompts mixed together.

We're essentially saying, on the general runtime, expect either `string` OR `SlateTextValue` for any of those individual properties. Don't worry about the overall node.