### PR TITLE
[Merged by Bors] - feat: menu node ids (CT-768)

### DIFF
--- a/packages/base-types/src/models/diagram.ts
+++ b/packages/base-types/src/models/diagram.ts
@@ -21,5 +21,10 @@ export interface Model<Node extends BaseDiagramNode = BaseDiagramNode> {
   modified: number;
   children: string[];
   variables: Variable[];
+  menuNodeIDs?: string[];
+
+  /**
+   * @deprecated use `menuNodeIDs` instead
+   */
   intentStepIDs?: string[];
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-768**

### Brief description. What is this change?

- add a new `menuNodeIDs` field to keep the order of nodes in the left menu
- deprecate intentStepIDs in favor of `menuNodeIDs`

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
