### PR TITLE
[Merged by Bors] - feat: added importable types for survey context (PL-37)

### DIFF
--- a/packages/alexa-types/src/version/index.ts
+++ b/packages/alexa-types/src/version/index.ts
@@ -9,6 +9,7 @@ import { defaultSettings, Settings } from './settings';
 
 export * from './publishing';
 export * from './settings';
+export * from './prototype';
 
 // shared only across voiceflow types
 

--- a/packages/alexa-types/src/version/index.ts
+++ b/packages/alexa-types/src/version/index.ts
@@ -3,6 +3,7 @@ import { AnyCommand } from '@alexa-types/node';
 import { BaseModels, DeepPartialByKey } from '@voiceflow/base-types';
 import { VoiceVersion } from '@voiceflow/voice-types';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
+import { AlexaSurveyContextExtension } from './prototype';
 
 import { defaultPublishing, Publishing } from './publishing';
 import { defaultSettings, Settings } from './settings';
@@ -25,7 +26,14 @@ export interface PlatformData extends VoiceVersion.PlatformData<Voice> {
   publishing: Publishing;
 }
 
-export interface Version extends VoiceVersion.Version<Voice, BaseModels.Version.Prototype<AnyCommand, VoiceflowConstants.Locale>> {
+export interface Version extends VoiceVersion.Version<
+  Voice, 
+  BaseModels.Version.Prototype<
+    AnyCommand, 
+    VoiceflowConstants.Locale,
+    AlexaSurveyContextExtension
+  >
+> {
   platformData: PlatformData;
 }
 

--- a/packages/alexa-types/src/version/index.ts
+++ b/packages/alexa-types/src/version/index.ts
@@ -3,8 +3,8 @@ import { AnyCommand } from '@alexa-types/node';
 import { BaseModels, DeepPartialByKey } from '@voiceflow/base-types';
 import { VoiceVersion } from '@voiceflow/voice-types';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
-import { AlexaSurveyContextExtension } from './prototype';
 
+import { AlexaSurveyContextExtension } from './prototype';
 import { defaultPublishing, Publishing } from './publishing';
 import { defaultSettings, Settings } from './settings';
 
@@ -26,14 +26,8 @@ export interface PlatformData extends VoiceVersion.PlatformData<Voice> {
   publishing: Publishing;
 }
 
-export interface Version extends VoiceVersion.Version<
-  Voice, 
-  BaseModels.Version.Prototype<
-    AnyCommand, 
-    VoiceflowConstants.Locale,
-    AlexaSurveyContextExtension
-  >
-> {
+export interface Version
+  extends VoiceVersion.Version<Voice, BaseModels.Version.Prototype<AnyCommand, VoiceflowConstants.Locale, AlexaSurveyContextExtension>> {
   platformData: PlatformData;
 }
 

--- a/packages/alexa-types/src/version/index.ts
+++ b/packages/alexa-types/src/version/index.ts
@@ -7,9 +7,9 @@ import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { defaultPublishing, Publishing } from './publishing';
 import { defaultSettings, Settings } from './settings';
 
+export * from './prototype';
 export * from './publishing';
 export * from './settings';
-export * from './prototype';
 
 // shared only across voiceflow types
 

--- a/packages/alexa-types/src/version/prototype.ts
+++ b/packages/alexa-types/src/version/prototype.ts
@@ -8,6 +8,6 @@ import { InterfaceType } from '../constants';
  */
 export interface AlexaSurveyContextExtension {
   products: Record<string, Product>;
-  permissions: Set<PermissionType>;
-  interfaces: Set<InterfaceType>;
+  permissions: PermissionType[];
+  interfaces: InterfaceType[];
 }

--- a/packages/alexa-types/src/version/prototype.ts
+++ b/packages/alexa-types/src/version/prototype.ts
@@ -1,0 +1,12 @@
+import { AlexaConstants, AlexaNode, AlexaProject } from "..";
+
+/**
+ * Stores survey results in Alexa projects
+ * 
+ * USAGE: BaseModels.Version.SurveyContext<AlexaSurveyContextExtension>
+ */
+export interface AlexaSurveyContextExtension {
+    products: Record<string, AlexaProject.Product>;
+    permissions: Set<AlexaNode.PermissionType>;
+    interfaces: Set<AlexaConstants.InterfaceType>;
+}

--- a/packages/alexa-types/src/version/prototype.ts
+++ b/packages/alexa-types/src/version/prototype.ts
@@ -1,12 +1,13 @@
-import { AlexaConstants, AlexaNode, AlexaProject } from "..";
+import { PermissionType } from '@alexa-types/node';
+import { Product } from '@alexa-types/project';
+
+import { InterfaceType } from '../constants';
 
 /**
  * Stores survey results in Alexa projects
- * 
- * USAGE: BaseModels.Version.SurveyContext<AlexaSurveyContextExtension>
  */
 export interface AlexaSurveyContextExtension {
-    products: Record<string, AlexaProject.Product>;
-    permissions: Set<AlexaNode.PermissionType>;
-    interfaces: Set<AlexaConstants.InterfaceType>;
+  products: Record<string, Product>;
+  permissions: Set<PermissionType>;
+  interfaces: Set<InterfaceType>;
 }

--- a/packages/base-types/src/models/version/index.ts
+++ b/packages/base-types/src/models/version/index.ts
@@ -45,7 +45,12 @@ export interface Folder {
 
 export type DefaultStepColors = Partial<Record<NodeType, string>>;
 
-export interface Model<_PlatformData extends PlatformData, Command extends BaseCommand = BaseCommand, Locale extends string = string> {
+export interface Model<
+  _PlatformData extends PlatformData, 
+  Command extends BaseCommand = BaseCommand, 
+  Locale extends string = string,
+  SurveyContextExt extends AnyRecord = AnyRecord
+> {
   _id: string;
   _version?: number;
   creatorID: number;
@@ -57,7 +62,7 @@ export interface Model<_PlatformData extends PlatformData, Command extends BaseC
   domains?: Domain[];
   folders?: Record<string, Folder>;
   variables: Variable[];
-  prototype?: Prototype<Command, Locale>;
+  prototype?: Prototype<Command, Locale, SurveyContextExt>;
   components?: FolderItem[];
   platformData: _PlatformData;
   canvasTemplates?: CanvasTemplate[];

--- a/packages/base-types/src/models/version/index.ts
+++ b/packages/base-types/src/models/version/index.ts
@@ -46,8 +46,8 @@ export interface Folder {
 export type DefaultStepColors = Partial<Record<NodeType, string>>;
 
 export interface Model<
-  _PlatformData extends PlatformData, 
-  Command extends BaseCommand = BaseCommand, 
+  _PlatformData extends PlatformData,
+  Command extends BaseCommand = BaseCommand,
   Locale extends string = string,
   SurveyContextExt extends AnyRecord = AnyRecord
 > {

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -41,10 +41,10 @@ export interface PrototypeSettings {
 }
 
 export type SurveyContext<SurveyContextExtension extends AnyRecord = AnyRecord, PlatformType extends string = string> = {
-  slotsMap: Map<string, Slot>;
+  slotsMap: Record<string, Slot>;
   extraSlots: Slot[];
   extraIntents: Intent[];
-  usedIntentsSet: Set<string>;
+  usedIntentsSet: string[];
   platform: PlatformType;
 } & SurveyContextExtension;
 

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -1,6 +1,6 @@
 import { AnyRecord, Nullable } from '@voiceflow/common';
 
-import { BaseCommand, PrototypeModel } from '../base';
+import { BaseCommand, Intent, PrototypeModel, Slot } from '../base';
 
 export interface PrototypeStackFrame<Command extends BaseCommand = BaseCommand> {
   nodeID?: Nullable<string>;
@@ -40,11 +40,20 @@ export interface PrototypeSettings {
   variableStateID?: string;
 }
 
-export interface Prototype<Command extends BaseCommand = BaseCommand, Locale extends string = string> {
+export type SurveyContext<SurveyContextExtension extends AnyRecord = AnyRecord> = {
+  slotsMap: Record<string, Slot>;
+  extraSlots: Slot[];
+  extraIntents: Intent[];
+  usedIntentsSet: string[];
+  platform: string; // VoiceflowConstants.PlatformType
+} & SurveyContextExtension;
+
+export interface Prototype<Command extends BaseCommand = BaseCommand, Locale extends string = string, SurveyContextExtension extends AnyRecord = AnyRecord> {
   type: string;
   data: PrototypeData<Locale>;
   model: PrototypeModel;
   context: PrototypeContext<Command>;
   platform: string;
   settings: PrototypeSettings;
+  surveyorContext: SurveyContext<SurveyContextExtension>;
 }

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -40,12 +40,12 @@ export interface PrototypeSettings {
   variableStateID?: string;
 }
 
-export type SurveyContext<SurveyContextExtension extends AnyRecord = AnyRecord> = {
-  slotsMap: Record<string, Slot>;
+export type SurveyContext<SurveyContextExtension extends AnyRecord = AnyRecord, PlatformType extends string = string> = {
+  slotsMap: Map<string, Slot>;
   extraSlots: Slot[];
   extraIntents: Intent[];
-  usedIntentsSet: string[];
-  platform: string; // VoiceflowConstants.PlatformType
+  usedIntentsSet: Set<string>;
+  platform: PlatformType;
 } & SurveyContextExtension;
 
 export interface Prototype<

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -48,7 +48,11 @@ export type SurveyContext<SurveyContextExtension extends AnyRecord = AnyRecord> 
   platform: string; // VoiceflowConstants.PlatformType
 } & SurveyContextExtension;
 
-export interface Prototype<Command extends BaseCommand = BaseCommand, Locale extends string = string, SurveyContextExtension extends AnyRecord = AnyRecord> {
+export interface Prototype<
+  Command extends BaseCommand = BaseCommand,
+  Locale extends string = string,
+  SurveyContextExtension extends AnyRecord = AnyRecord
+> {
   type: string;
   data: PrototypeData<Locale>;
   model: PrototypeModel;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -64,3 +64,24 @@ export type TupleFirst<T> = T extends Tuple<infer R, any> ? R : never;
 export type TupleSecond<T> = T extends Tuple<any, infer R> ? R : never;
 
 export type Pair<T> = Tuple<T, T>;
+
+/**
+ * Given a type with non-primitive types, i.e, Map and Set, converts the type
+ * into the equivalent serialized type, which can be stored in a database or 
+ * transmitted over the network.
+ */
+export type Serialized<T> =
+  /* Base case 1 - Set is serialized to an array */
+  T extends Set<infer ElementType>              
+    ? ElementType[]
+  
+  /* Base case 2 - Map is serialized to object */
+  : T extends Map<infer Key extends string | symbol | number, infer Value> 
+    ? Record<Key, Value>
+
+  /* Recursive case - Serialize each property of the object */
+  : T extends Record<any, any>            
+    ? { [Property in keyof T]: Serialized<T[Property]> }
+
+  /* Base case 3 - Primitive type is unchanged */
+  : T;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -64,24 +64,3 @@ export type TupleFirst<T> = T extends Tuple<infer R, any> ? R : never;
 export type TupleSecond<T> = T extends Tuple<any, infer R> ? R : never;
 
 export type Pair<T> = Tuple<T, T>;
-
-/**
- * Given a type with non-primitive types, i.e, Map and Set, converts the type
- * into the equivalent serialized type, which can be stored in a database or 
- * transmitted over the network.
- */
-export type Serialized<T> =
-  /* Base case 1 - Set is serialized to an array */
-  T extends Set<infer ElementType>              
-    ? ElementType[]
-  
-  /* Base case 2 - Map is serialized to object */
-  : T extends Map<infer Key extends string | symbol | number, infer Value> 
-    ? Record<Key, Value>
-
-  /* Recursive case - Serialize each property of the object */
-  : T extends Record<any, any>            
-    ? { [Property in keyof T]: Serialized<T[Property]> }
-
-  /* Base case 3 - Primitive type is unchanged */
-  : T;

--- a/packages/google-dfes-types/src/version/base.ts
+++ b/packages/google-dfes-types/src/version/base.ts
@@ -1,8 +1,9 @@
 import { Locale } from '@google-dfes-types/constants';
 import { AnyCommand } from '@google-dfes-types/node';
 import { BaseModels } from '@voiceflow/base-types';
+import { GoogleVersion } from '@voiceflow/google-types';
 
-export interface BasePrototype extends BaseModels.Version.Prototype<AnyCommand, Locale> {}
+export interface BasePrototype extends BaseModels.Version.Prototype<AnyCommand, Locale, GoogleVersion.GaDfesSurveyContextExtension> {}
 
 export interface BasePublishing {
   locales: Locale[];

--- a/packages/google-types/src/version/base/index.ts
+++ b/packages/google-types/src/version/base/index.ts
@@ -1,8 +1,8 @@
 import { Locale } from '@google-types/constants';
 import { AnyCommand } from '@google-types/node';
 import { BaseModels, DeepPartialByKey } from '@voiceflow/base-types';
-import { GaDfesSurveyContextExtension } from '../prototype';
 
+import { GaDfesSurveyContextExtension } from '../prototype';
 import { defaultSharedBasePublishing, SharedBasePublishing } from './publishing';
 
 export * from './publishing';

--- a/packages/google-types/src/version/base/index.ts
+++ b/packages/google-types/src/version/base/index.ts
@@ -1,12 +1,13 @@
 import { Locale } from '@google-types/constants';
 import { AnyCommand } from '@google-types/node';
 import { BaseModels, DeepPartialByKey } from '@voiceflow/base-types';
+import { GaDfesSurveyContextExtension } from '../prototype';
 
 import { defaultSharedBasePublishing, SharedBasePublishing } from './publishing';
 
 export * from './publishing';
 
-export interface BasePrototype extends BaseModels.Version.Prototype<AnyCommand, Locale> {}
+export interface BasePrototype extends BaseModels.Version.Prototype<AnyCommand, Locale, GaDfesSurveyContextExtension> {}
 
 export enum Stage {
   DEV = 'DEV',

--- a/packages/google-types/src/version/index.ts
+++ b/packages/google-types/src/version/index.ts
@@ -23,8 +23,8 @@ import {
 
 export * from './base';
 export * from './chat';
-export * from './voice';
 export * from './prototype';
+export * from './voice';
 
 export interface PlatformDataPerType {
   [VoiceflowConstants.ProjectType.CHAT]: ChatPlatformData;

--- a/packages/google-types/src/version/index.ts
+++ b/packages/google-types/src/version/index.ts
@@ -24,6 +24,7 @@ import {
 export * from './base';
 export * from './chat';
 export * from './voice';
+export * from './prototype';
 
 export interface PlatformDataPerType {
   [VoiceflowConstants.ProjectType.CHAT]: ChatPlatformData;

--- a/packages/google-types/src/version/prototype.ts
+++ b/packages/google-types/src/version/prototype.ts
@@ -2,5 +2,5 @@
  * Stores survey results in GA and DFES projects
  */
 export interface GaDfesSurveyContextExtension {
-  goToIntentsSet: Set<string>;
+  goToIntentsSet: string[];
 }

--- a/packages/google-types/src/version/prototype.ts
+++ b/packages/google-types/src/version/prototype.ts
@@ -1,0 +1,8 @@
+/**
+ * Stores survey results in GA and DFES projects
+ * 
+ * USAGE: BaseModels.Version.SurveyContext<GaDfesSurveyContextExtension>
+ */
+export interface GaDfesSurveyContextExtension {
+    goToIntentsSet: Set<string>;
+}

--- a/packages/google-types/src/version/prototype.ts
+++ b/packages/google-types/src/version/prototype.ts
@@ -2,5 +2,5 @@
  * Stores survey results in GA and DFES projects
  */
 export interface GaDfesSurveyContextExtension {
-    goToIntentsSet: Set<string>;
+  goToIntentsSet: Set<string>;
 }

--- a/packages/google-types/src/version/prototype.ts
+++ b/packages/google-types/src/version/prototype.ts
@@ -1,7 +1,5 @@
 /**
  * Stores survey results in GA and DFES projects
- * 
- * USAGE: BaseModels.Version.SurveyContext<GaDfesSurveyContextExtension>
  */
 export interface GaDfesSurveyContextExtension {
     goToIntentsSet: Set<string>;

--- a/packages/google-types/src/version/prototype.ts
+++ b/packages/google-types/src/version/prototype.ts
@@ -2,5 +2,5 @@
  * Stores survey results in GA and DFES projects
  */
 export interface GaDfesSurveyContextExtension {
-  goToIntentsSet: string[];
+  goToIntentsSet: Set<string>;
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-37**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adds typing for `surveyorContext` on the `Version` data. 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Added a `SurveyContext` type for the `version.prototype.surveyorContext` property. 

The `SurveyContext` can be extended by the `SurveyContextExtension` type.

Each channel extends the survey context with its own properties: `AlexaSurveyContextExtension` or `GaDfesSurveyContextExtension`. 

The original source of truth of `SurveyContext` is actually in this file: `general-service/lib/clients/platform/types.ts`. I've just broken it up so that the domain-specific properties belong to the domain-specific type package, and allowed the survey context to be shared. 

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

1. `libs` - Can be merged now
2. `general-service` - Can be merged after `libs`
3. `alexa-service` + `google-service` - Merged *after* the `prototype-programs` migration is done

### Related PRs

<!-- List related PRs against other branches -->

- Blocked by: https://github.com/voiceflow/creator-app/pull/5881

- https://github.com/voiceflow/libs/pull/359
- https://github.com/voiceflow/alexa-service/pull/294
- https://github.com/voiceflow/general-service/pull/396
- https://github.com/voiceflow/google-service/pull/311

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
