### PR TITLE
[Merged by Bors] - feat: allow template color as null (CT-674)

### DIFF
--- a/packages/base-types/src/models/version/canvasTemplate.ts
+++ b/packages/base-types/src/models/version/canvasTemplate.ts
@@ -1,6 +1,6 @@
 export interface CanvasTemplate {
   id: string;
   name: string;
-  color: string;
+  color: string | null;
   nodeIDs: string[];
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-674**
 - When user didn't select a color, we should apply that color for the template. I added this logic on the frontend, but we need to allow null on the base-types.