### PR TITLE
[Merged by Bors] - feat: add base publishing property (CT-000)

### DIFF
--- a/packages/alexa-types/src/version/publishing.ts
+++ b/packages/alexa-types/src/version/publishing.ts
@@ -1,6 +1,7 @@
 import { Locale } from '@alexa-types/constants';
+import { BaseVersion } from '@voiceflow/base-types';
 
-export interface Publishing {
+export interface Publishing extends BaseVersion.Publishing {
   forExport: boolean;
   hasAds: boolean;
   summary: string;

--- a/packages/base-types/src/version/index.ts
+++ b/packages/base-types/src/version/index.ts
@@ -1,11 +1,13 @@
 import { Version as VersionModels } from '@base-types/models';
 import { DeepPartialByKey } from '@base-types/types';
 
+import { Publishing } from './publishing';
 import { defaultSettings, Settings } from './settings';
 
+export * from './publishing';
 export * from './settings';
 
-export interface PlatformData<Prompt = unknown> extends VersionModels.PlatformData<Settings<Prompt>> {}
+export interface PlatformData<Prompt = unknown> extends VersionModels.PlatformData<Settings<Prompt>, Publishing> {}
 
 export interface Version<Prompt = unknown, Prototype extends VersionModels.Prototype = VersionModels.Prototype>
   extends VersionModels.Model<PlatformData<Prompt>> {

--- a/packages/base-types/src/version/publishing.ts
+++ b/packages/base-types/src/version/publishing.ts
@@ -1,0 +1,3 @@
+export interface Publishing {
+  selectedIntents?: string[];
+}

--- a/packages/chat-types/src/version/index.ts
+++ b/packages/chat-types/src/version/index.ts
@@ -8,6 +8,7 @@ export * from './settings';
 export interface PlatformData extends BaseVersion.PlatformData<Prompt> {
   intents: Intent[];
   settings: Settings;
+  publishing: BaseVersion.Publishing;
 }
 
 export interface Version<Prototype extends BaseModels.Version.Prototype = BaseModels.Version.Prototype>

--- a/packages/google-dfes-types/src/version/base.ts
+++ b/packages/google-dfes-types/src/version/base.ts
@@ -1,11 +1,11 @@
 import { Locale } from '@google-dfes-types/constants';
 import { AnyCommand } from '@google-dfes-types/node';
-import { BaseModels } from '@voiceflow/base-types';
+import { BaseModels, BaseVersion } from '@voiceflow/base-types';
 import { GoogleVersion } from '@voiceflow/google-types';
 
 export interface BasePrototype extends BaseModels.Version.Prototype<AnyCommand, Locale, GoogleVersion.GaDfesSurveyContextExtension> {}
 
-export interface BasePublishing {
+export interface BasePublishing extends BaseVersion.Publishing {
   locales: Locale[];
   agentName?: string;
   triggerPhrase?: string[];

--- a/packages/google-types/src/version/base/publishing.ts
+++ b/packages/google-types/src/version/base/publishing.ts
@@ -1,7 +1,8 @@
 import { Category, Locale } from '@google-types/constants';
+import { BaseVersion } from '@voiceflow/base-types';
 
 // shared across google and dfes types
-export interface SharedBasePublishing {
+export interface SharedBasePublishing extends BaseVersion.Publishing {
   // localized settings
   voice: string;
   displayName: string;
@@ -61,7 +62,7 @@ export const defaultSharedBasePublishing = ({
 });
 
 // shared only across google types
-export interface BasePublishing {
+export interface BasePublishing extends BaseVersion.Publishing {
   locales: Locale[];
 }
 


### PR DESCRIPTION
As part of my recent dialogflowCX work, I've had to add a `selectedIntents` field under `version.platformData.publishing`
This data needs to be persisted so we can configure it from different areas of the app.

The publishing job will read this value and use it to decide which intents to upload. We can see it here as part of the dialogflowCX publishing process:
![Screen Shot 2022-09-27 at 5 09 20 PM](https://user-images.githubusercontent.com/5643574/192635976-0751f3bc-b9de-4433-88ac-85e456ad7c5e.png)
https://github.com/voiceflow/google-service/blob/1bc9a877afc784d7d5140cfd024005b10b0c8668/lib/jobs/dialogflow/cx/publish/stages/agent.ts#L168-L173

This might be a requirement for additional NLPs we upload to in the future. Right now publishing is just `Record<string, any>` so this will help it be more definitively typed.