### PR TITLE
[Merged by Bors] - fix: resolve belgium dutch (BUG-45)

### DIFF
--- a/packages/google-types/src/constants/locales.ts
+++ b/packages/google-types/src/constants/locales.ts
@@ -146,6 +146,7 @@ export enum VoiceLanguageCode {
   ML_IN = 'ml-IN',
   NB_NO = 'nb-NO',
   NL_NL = 'nl-NL',
+  NL_BE = 'nl-BE',
   PL_PL = 'pl-PL',
   PT_BR = 'pt-BR',
   PT_PT = 'pt-PT',
@@ -170,7 +171,7 @@ export const LocaleToVoiceLanguageCode: Record<Locale, VoiceLanguageCode> = {
   [Locale.DE_BE]: VoiceLanguageCode.DE_DE,
 
   [Locale.NL_NL]: VoiceLanguageCode.NL_NL,
-  [Locale.NL_BE]: VoiceLanguageCode.NL_NL,
+  [Locale.NL_BE]: VoiceLanguageCode.NL_BE,
 
   [Locale.EN_US]: VoiceLanguageCode.EN_US,
   [Locale.EN_CA]: VoiceLanguageCode.EN_US,

--- a/packages/google-types/src/constants/voices.ts
+++ b/packages/google-types/src/constants/voices.ts
@@ -367,6 +367,20 @@ export const VoiceLanguageCodeToVoice: Record<VoiceLanguageCode, GoogleVoice[]> 
       ssmlGender: `${SSMLGender.FEMALE}-3`,
     },
   ],
+  [VoiceLanguageCode.NL_BE]: [
+    {
+      voiceLanguage: VoiceLanguage.DUTCH_BELGIUM,
+      voiceType: [VoiceType.WAVENET, VoiceType.STANDARD],
+      voiceName: [`${VoiceLanguageCode.NL_BE}-${VoiceType.WAVENET}-A`, `${VoiceLanguageCode.NL_BE}-${VoiceType.STANDARD}-A`],
+      ssmlGender: `${SSMLGender.FEMALE}-1`,
+    },
+    {
+      voiceLanguage: VoiceLanguage.DUTCH_BELGIUM,
+      voiceType: [VoiceType.WAVENET, VoiceType.STANDARD],
+      voiceName: [`${VoiceLanguageCode.NL_BE}-${VoiceType.WAVENET}-B`, `${VoiceLanguageCode.NL_BE}-${VoiceType.STANDARD}-B`],
+      ssmlGender: `${SSMLGender.MALE}-1`,
+    },
+  ],
   [VoiceLanguageCode.FR_FR]: [
     {
       voiceLanguage: VoiceLanguage.FRENCH_FRANCE,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements BUG-45**

### Brief description. What is this change?
So Belgium dutch is it's own thing, like how there is Canadian French: `fr-CA`
![Screen Shot 2022-09-28 at 12 02 21 PM](https://user-images.githubusercontent.com/5643574/192829014-bcd32676-64f3-4f5a-a31e-7c536fa8d1f6.png)

Note that there is no Langauge for Belgium French, but there is a locale. it's just `fr-FR`:
https://developers.google.com/assistant/console/languages-locales#french