### PR TITLE
[Merged by Bors] - feat: upload custom tls certificate for api calls (PL-120)

### DIFF
--- a/packages/base-types/src/node/api.ts
+++ b/packages/base-types/src/node/api.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '@voiceflow/common';
+import { AnyRecord, Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
 import { BaseStep, IntegrationType, NodeSuccessFailID, SuccessFailStepPorts } from './utils';
@@ -48,6 +48,7 @@ export interface StepData {
   bodyType: APIBodyType;
   selectedAction: APIActionType;
   selectedIntegration: IntegrationType.CUSTOM_API;
+  tls?: { cert?: string; key?: string };
 }
 
 export interface StepPorts extends SuccessFailStepPorts<[]> {}
@@ -63,11 +64,12 @@ export interface NodeData extends NodeSuccessFailID {
     content: string;
     bodyInputType: APIBodyType;
     selected_action: APIActionType;
+    tls?: { cert?: string; key?: string };
   };
   selected_action: APIActionType;
   selected_integration: IntegrationType.CUSTOM_API;
 }
 
-export interface Step<Data = StepData> extends BaseStep<Data, StepPorts> {
+export interface Step<Data extends AnyRecord = StepData> extends BaseStep<Data, StepPorts> {
   type: NodeType.API;
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-120**

### Brief description. What is this change?
Adds an optional `tls` field to `StepData` and `NodeData`. The `tls` field contains a `cert` and `key` field which are both optional strings.
<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
This change is part of PL-120. It allows the key name of a certificate and key to be stored on a node and then used to retrieve the actual file at runtime.
### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->
- When someone uploads a certificate/key, it is uploaded to S3 and filename is stored on the node.
- The changes corresponding to this PR takes the filename from the node on the diagram and put it on the node in the program.
- The filename from the node on the program can be used to retrieve the file from S3 at runtime.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
