### PR TITLE
[Merged by Bors] - fix: channel action payload (PL-000)

### DIFF
--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -97,7 +97,7 @@ export interface LogTrace extends BaseTraceFrame<LogTracePayload> {
 
 export interface ChannelActionTracePayload {
   name: string;
-  data: AnyRecord;
+  payload: AnyRecord;
 }
 
 export interface ChannelActionTrace extends BaseTraceFrame<ChannelActionTracePayload> {


### PR DESCRIPTION
**Fixes or implements PL-000**

### Brief description. What is this change?
There is a bug on the type of the channel aciton **trace** payload.

[here](https://github.com/voiceflow/general-runtime/blob/master/lib/services/runtime/handlers/channelAction.ts#L16) you can see its payload should actually be a [object with a payload prop, not data](https://github.com/voiceflow/libs/blob/master/packages/base-types/src/node/channelAction.ts#L32)