### PR TITLE
[Merged by Bors] - feat: added version tag to base-types so the value can be shared (PL-000)

### DIFF
--- a/packages/base-types/src/version/tag.ts
+++ b/packages/base-types/src/version/tag.ts
@@ -1,0 +1,11 @@
+export enum VersionTag {
+  /**
+   * Tag value for Voiceflow version deployed in the production slot
+   */
+  PRODUCTION = 'production',
+
+  /**
+   * Tag value for Voiceflow version deployed in the development slot
+   */
+  DEVELOPMENT = 'development',
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-000**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adds new `VersionTag` enum that will be shared with various services in the codebases, rather than each service defining its own instance of `VersionTag`

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Added `VersionTag` enum

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

None

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

None

### Related PRs

<!-- List related PRs against other branches -->

None

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
