### PR TITLE
[Merged by Bors] - fix: export version tag (PL-000)

### DIFF
--- a/packages/base-types/src/version/index.ts
+++ b/packages/base-types/src/version/index.ts
@@ -6,6 +6,7 @@ import { defaultSettings, Settings } from './settings';
 
 export * from './publishing';
 export * from './settings';
+export * from './tag';
 
 export interface PlatformData<Prompt = unknown> extends VersionModels.PlatformData<Settings<Prompt>, Publishing> {}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

The version tags were not being exported, now they can be accessed from `Version.VersionTag`