### PR TITLE
[Merged by Bors] - feat: add baseURL option (DX-245)

### DIFF
--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -20,7 +20,7 @@ This is a universal library and can be used in the browser or in a Node.JS envir
 ```ts
 import { FetchClient } from '@voiceflow/fetch';
 
-const fetch = new FetchClient();
+const fetch = new FetchClient({ /* options */ });
 ```
 
 ### Node Usage
@@ -29,8 +29,12 @@ const fetch = new FetchClient();
 import { FetchClient } from '@voiceflow/fetch';
 import * as undici from 'undici';
 
-const fetch = new FetchClient(undici.fetch);
+const fetch = new FetchClient(undici.fetch, { /* options */ });
 ```
+
+## Options
+
+- __`baseURL`__ (`string`): this will be added as a prefix to the URL of all requests
 
 ## Features
 
@@ -78,6 +82,16 @@ fetch.head('/foo');   // HEAD   /foo
 fetch.patch('/foo');  // PATCH  /foo
 fetch.post('/foo');   // POST   /foo
 fetch.put('/foo');    // PUT    /foo
+```
+
+### Base URL
+
+Specify a base URL which should be used to build every request.
+
+```ts
+const fetch = new FetchClient({ baseURL: 'http://example.com/' });
+
+fetch.get('foo'); // GET http://example.com/foo
 ```
 
 ### Throws on non-2xx

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -94,6 +94,15 @@ const fetch = new FetchClient({ baseURL: 'http://example.com/' });
 fetch.get('foo'); // GET http://example.com/foo
 ```
 
+If you make a request using a `URL` instance then the `baseURL` option will be ignored.
+
+```ts
+const fetch = new FetchClient({ baseURL: 'http://example.com/' });
+const url = new URL('http://foo.com/bar');
+
+fetch.get(url); // GET http://foo.com/bar
+```
+
 ### Throws on non-2xx
 
 If any non-`2xx` HTTP status is returned then a `ClientException` from `@voiceflow/exception` is thrown.

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -20,7 +20,7 @@ This is a universal library and can be used in the browser or in a Node.JS envir
 ```ts
 import { FetchClient } from '@voiceflow/fetch';
 
-const fetch = new FetchClient({ /* options */ });
+const fetch = new FetchClient({ /* config */ });
 ```
 
 ### Node Usage
@@ -29,10 +29,10 @@ const fetch = new FetchClient({ /* options */ });
 import { FetchClient } from '@voiceflow/fetch';
 import * as undici from 'undici';
 
-const fetch = new FetchClient(undici.fetch, { /* options */ });
+const fetch = new FetchClient(undici.fetch, { /* config */ });
 ```
 
-## Options
+## Configuration
 
 - __`baseURL`__ (`string`): this will be added as a prefix to the URL of all requests
 

--- a/packages/fetch/src/client-configuration.interface.ts
+++ b/packages/fetch/src/client-configuration.interface.ts
@@ -1,0 +1,3 @@
+export interface ClientConfiguration {
+  baseURL?: string;
+}

--- a/packages/fetch/src/fetch-client-options.interface.ts
+++ b/packages/fetch/src/fetch-client-options.interface.ts
@@ -1,3 +1,0 @@
-export interface FetchClientOptions {
-  baseURL?: string;
-}

--- a/packages/fetch/src/fetch-client-options.interface.ts
+++ b/packages/fetch/src/fetch-client-options.interface.ts
@@ -1,0 +1,3 @@
+export interface FetchClientOptions {
+  baseURL?: string;
+}

--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -177,6 +177,16 @@ describe('Fetch Client', () => {
 
       expect(sandbox.done()).to.be.true;
     });
+
+    it('should not prefix request using URL instance', async () => {
+      const url = new NodeURL(TARGET_URL);
+      const fetchSpy = sinon.spy<NodeFetch>(async () => new undici.Response());
+      const fetchClient = new FetchClient(fetchSpy, { baseURL: 'http://foo.com/' });
+
+      await fetchClient.get(url);
+
+      expect(fetchSpy).to.be.calledWithExactly(url, { method: 'get', headers: {}, body: undefined });
+    });
   });
 
   describe('error handling', () => {

--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -166,7 +166,7 @@ describe('Fetch Client', () => {
     });
   });
 
-  describe('#options.baseURL', () => {
+  describe('#config.baseURL', () => {
     it('should prefix request URL with provided baseURL option', async () => {
       const baseURL = 'http://example.com/';
       const path = 'foo/bar';

--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -166,6 +166,19 @@ describe('Fetch Client', () => {
     });
   });
 
+  describe('#options.baseURL', () => {
+    it('should prefix request URL with provided baseURL option', async () => {
+      const baseURL = 'http://example.com/';
+      const path = 'foo/bar';
+      const fetch = new FetchClient(sandbox, { baseURL });
+      sandbox.get(`${baseURL}${path}`, 200);
+
+      await fetch.get(path);
+
+      expect(sandbox.done()).to.be.true;
+    });
+  });
+
   describe('error handling', () => {
     it('should throw ClientException on non-2xx status code', async () => {
       const fetch = new FetchClient(sandbox);

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -1,11 +1,27 @@
 import { ClientException } from '@voiceflow/exception';
 
 import { FetchAPI, FetchOptions, FetchResponse } from './fetch.interface';
+import { FetchClientOptions } from './fetch-client-options.interface';
 import { HTTPMethod } from './http-method.enum';
 import { RequestOptions } from './request-options.interface';
 
 export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req = URL | Request, Res extends FetchResponse = Response> {
-  constructor(private readonly fetch?: FetchAPI<Opts, Req, Res>) {}
+  private readonly options: FetchClientOptions;
+
+  private readonly fetch: FetchAPI<Opts, Req, Res> | undefined;
+
+  /* eslint-disable lines-between-class-members */
+  constructor(options?: FetchClientOptions);
+  constructor(fetch: FetchAPI<Opts, Req, Res>, options?: FetchClientOptions);
+  constructor(fetchOrOptions?: FetchAPI<Opts, Req, Res> | FetchClientOptions, options?: FetchClientOptions) {
+    if (typeof fetchOrOptions === 'function') {
+      this.fetch = fetchOrOptions;
+      this.options = options ?? {};
+    } else {
+      this.options = fetchOrOptions ?? {};
+    }
+  }
+  /* eslint-enable lines-between-class-members */
 
   private async send(url: string | Req, rawOptions: RequestOptions<Opts>) {
     const { json, ...options } = rawOptions;
@@ -18,7 +34,7 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
       body = JSON.stringify(json);
     }
 
-    const response = await this.raw(url, { ...options, headers, body } as Opts);
+    const response = await this.raw(`${this.options.baseURL ?? ''}${url}`, { ...options, headers, body } as Opts);
 
     if (!response.ok) {
       throw await new ClientException(response).build();

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -34,7 +34,8 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
       body = JSON.stringify(json);
     }
 
-    const response = await this.raw(`${this.config.baseURL ?? ''}${url}`, { ...options, headers, body } as Opts);
+    const finalURL = typeof url === 'string' ? `${this.config.baseURL ?? ''}${url}` : url;
+    const response = await this.raw(finalURL, { ...options, headers, body } as Opts);
 
     if (!response.ok) {
       throw await new ClientException(response).build();

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -1,24 +1,24 @@
 import { ClientException } from '@voiceflow/exception';
 
+import { ClientConfiguration } from './client-configuration.interface';
 import { FetchAPI, FetchOptions, FetchResponse } from './fetch.interface';
-import { FetchClientOptions } from './fetch-client-options.interface';
 import { HTTPMethod } from './http-method.enum';
 import { RequestOptions } from './request-options.interface';
 
 export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req = URL | Request, Res extends FetchResponse = Response> {
-  private readonly options: FetchClientOptions;
+  private readonly config: ClientConfiguration;
 
   private readonly fetch: FetchAPI<Opts, Req, Res> | undefined;
 
   /* eslint-disable lines-between-class-members */
-  constructor(options?: FetchClientOptions);
-  constructor(fetch: FetchAPI<Opts, Req, Res>, options?: FetchClientOptions);
-  constructor(fetchOrOptions?: FetchAPI<Opts, Req, Res> | FetchClientOptions, options?: FetchClientOptions) {
-    if (typeof fetchOrOptions === 'function') {
-      this.fetch = fetchOrOptions;
-      this.options = options ?? {};
+  constructor(config?: ClientConfiguration);
+  constructor(fetch: FetchAPI<Opts, Req, Res>, options?: ClientConfiguration);
+  constructor(fetchOrConfig?: FetchAPI<Opts, Req, Res> | ClientConfiguration, config?: ClientConfiguration) {
+    if (typeof fetchOrConfig === 'function') {
+      this.fetch = fetchOrConfig;
+      this.config = config ?? {};
     } else {
-      this.options = fetchOrOptions ?? {};
+      this.config = fetchOrConfig ?? {};
     }
   }
   /* eslint-enable lines-between-class-members */
@@ -34,7 +34,7 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
       body = JSON.stringify(json);
     }
 
-    const response = await this.raw(`${this.options.baseURL ?? ''}${url}`, { ...options, headers, body } as Opts);
+    const response = await this.raw(`${this.config.baseURL ?? ''}${url}`, { ...options, headers, body } as Opts);
 
     if (!response.ok) {
       throw await new ClientException(response).build();

--- a/packages/fetch/src/main.ts
+++ b/packages/fetch/src/main.ts
@@ -1,5 +1,5 @@
 export * from './fetch.client';
 export * from './fetch.interface';
-export * from './fetch-client-options.interface';
+export * from './client-configuration.interface';
 export * from './http-method.enum';
 export * from './request-options.interface';

--- a/packages/fetch/src/main.ts
+++ b/packages/fetch/src/main.ts
@@ -1,4 +1,5 @@
 export * from './fetch.client';
 export * from './fetch.interface';
+export * from './fetch-client-options.interface';
 export * from './http-method.enum';
 export * from './request-options.interface';

--- a/packages/fetch/src/main.ts
+++ b/packages/fetch/src/main.ts
@@ -1,5 +1,5 @@
+export * from './client-configuration.interface';
 export * from './fetch.client';
 export * from './fetch.interface';
-export * from './client-configuration.interface';
 export * from './http-method.enum';
 export * from './request-options.interface';


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-245**

### Brief description. What is this change?

Add `config.baseURL` which can be used to add a prefix to all request URLs

```ts
const fetch = new FetchClient({ baseURL: 'http://example.com/' });

fetch.get('foo'); // GET http://example.com/foo
```

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
