### PR TITLE
[Merged by Bors] - feat: add Map support for headers in fetch request options (vf-000)

### DIFF
--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -93,6 +93,28 @@ describe('Fetch Client', () => {
     });
   });
 
+  describe('request options', () => {
+    it('should accept headers as a Map', async () => {
+      const fetch = new FetchClient(sandbox);
+      const headers = new Map([['foo', 'bar']]);
+      sandbox.get({ url: TARGET_URL, headers: { foo: 'bar' } }, 200);
+
+      await fetch.get(TARGET_URL, { headers });
+
+      expect(sandbox.done()).to.be.true;
+    });
+
+    it('should accept headers as an object', async () => {
+      const fetch = new FetchClient(sandbox);
+      const headers = { foo: 'bar' };
+      sandbox.get({ url: TARGET_URL, headers }, 200);
+
+      await fetch.get(TARGET_URL, { headers });
+
+      expect(sandbox.done()).to.be.true;
+    });
+  });
+
   describe('#delete()', () => {
     it('should send DELETE request', async () => {
       const fetch = new FetchClient(sandbox);

--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -93,28 +93,6 @@ describe('Fetch Client', () => {
     });
   });
 
-  describe('request options', () => {
-    it('should accept headers as a Map', async () => {
-      const fetch = new FetchClient(sandbox);
-      const headers = new Map([['foo', 'bar']]);
-      sandbox.get({ url: TARGET_URL, headers: { foo: 'bar' } }, 200);
-
-      await fetch.get(TARGET_URL, { headers });
-
-      expect(sandbox.done()).to.be.true;
-    });
-
-    it('should accept headers as an object', async () => {
-      const fetch = new FetchClient(sandbox);
-      const headers = { foo: 'bar' };
-      sandbox.get({ url: TARGET_URL, headers }, 200);
-
-      await fetch.get(TARGET_URL, { headers });
-
-      expect(sandbox.done()).to.be.true;
-    });
-  });
-
   describe('#delete()', () => {
     it('should send DELETE request', async () => {
       const fetch = new FetchClient(sandbox);
@@ -208,6 +186,28 @@ describe('Fetch Client', () => {
       await fetchClient.get(url);
 
       expect(fetchSpy).to.be.calledWithExactly(url, { method: 'get', headers: {}, body: undefined });
+    });
+  });
+
+  describe('request options', () => {
+    it('should accept headers as a Map', async () => {
+      const fetch = new FetchClient(sandbox);
+      const headers = new Map([['foo', 'bar']]);
+      sandbox.get({ url: TARGET_URL, headers: { foo: 'bar' } }, 200);
+
+      await fetch.get(TARGET_URL, { headers });
+
+      expect(sandbox.done()).to.be.true;
+    });
+
+    it('should accept headers as an object', async () => {
+      const fetch = new FetchClient(sandbox);
+      const headers = { foo: 'bar' };
+      sandbox.get({ url: TARGET_URL, headers }, 200);
+
+      await fetch.get(TARGET_URL, { headers });
+
+      expect(sandbox.done()).to.be.true;
     });
   });
 

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -6,7 +6,7 @@ import { HTTPMethod } from './http-method.enum';
 import { RequestOptions } from './request-options.interface';
 
 export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req = URL | Request, Res extends FetchResponse = Response> {
-  static extractHeaders(headers: FetchOptions<any, any>['headers']) {
+  private static extractHeaders(headers: FetchOptions<any, any>['headers']) {
     if (headers instanceof Map) return new Map(headers);
 
     return new Map(Object.entries(headers));

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -6,6 +6,12 @@ import { HTTPMethod } from './http-method.enum';
 import { RequestOptions } from './request-options.interface';
 
 export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req = URL | Request, Res extends FetchResponse = Response> {
+  static extractHeaders(headers: FetchOptions<any, any>['headers']) {
+    if (headers instanceof Map) return new Map(headers);
+
+    return new Map(Object.entries(headers));
+  }
+
   private readonly config: ClientConfiguration;
 
   private readonly fetch: FetchAPI<Opts, Req, Res> | undefined;
@@ -26,16 +32,20 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
   private async send(url: string | Req, rawOptions: RequestOptions<Opts>) {
     const { json, ...options } = rawOptions;
 
-    const headers: Record<string, string> = { ...options.headers };
+    const headers = new Map(options.headers && FetchClient.extractHeaders(options.headers));
     let { body } = options;
 
     if (json != null) {
-      headers['content-type'] = 'application/json';
+      headers.set('content-type', 'application/json');
       body = JSON.stringify(json);
     }
 
     const finalURL = typeof url === 'string' ? `${this.config.baseURL ?? ''}${url}` : url;
-    const response = await this.raw(finalURL, { ...options, headers, body } as Opts);
+    const response = await this.raw(finalURL, {
+      ...options,
+      headers: Object.fromEntries(headers.entries()),
+      body,
+    } as Opts);
 
     if (!response.ok) {
       throw await new ClientException(response).build();

--- a/packages/fetch/src/request-options.interface.ts
+++ b/packages/fetch/src/request-options.interface.ts
@@ -2,7 +2,7 @@ import { FetchOptions } from './fetch.interface';
 
 interface ExtraOptions {
   json?: any;
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | Map<string, string>;
 }
 
 export type RequestOptions<Opts extends FetchOptions<any, any>> = Omit<Partial<Opts>, keyof ExtraOptions> & ExtraOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,14 +2175,6 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@voiceflow/base-types@^2.74.0":
-  version "2.74.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/base-types/-/base-types-2.74.0.tgz#f45843e235f5c728206baac12122f8369363c40a"
-  integrity sha512-B4JJfq/FE8+SOyFckRHxjX8wXq7pzcCA31mj/WNYIDxy/ApiJHmOUljlZMwO1iReBey66yuXJbSw3gV+zkP0BA==
-  dependencies:
-    "@voiceflow/common" "^8.1.5"
-    slate "0.73.0"
-
 "@voiceflow/commitlint-config@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@voiceflow/commitlint-config/-/commitlint-config-2.0.1.tgz#5559d875b543af2d823914f9c240905cb11d886f"


### PR DESCRIPTION
### Brief description. What is this change?

Allow fetch headers to be passed as a `Map`

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
