### PR TITLE
[Merged by Bors] - feat(fetch): support url search params (PL-000)

### DIFF
--- a/packages/fetch/config/test/setup.ts
+++ b/packages/fetch/config/test/setup.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line max-classes-per-file
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
@@ -10,6 +9,5 @@ Object.assign(global, {
   window: {
     fetch: () => undefined,
   },
-  URL: class {},
   Request: class {},
 });

--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -105,6 +105,18 @@ describe('Fetch Client', () => {
   });
 
   describe('#get()', () => {
+    it('should support url search params', async () => {
+      const expectedURL = `${TARGET_URL}?test=encode+this%26`;
+      const fetch = new FetchClient(sandbox);
+      sandbox.get(expectedURL, { status: 200 });
+
+      await fetch.get(TARGET_URL, {
+        searchParams: { test: 'encode this&' },
+      });
+
+      expect(sandbox.done()).to.be.true;
+    });
+
     it('should send GET request', async () => {
       const data = { foo: 'bar' };
       const fetch = new FetchClient(sandbox);

--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -111,7 +111,7 @@ describe('Fetch Client', () => {
       sandbox.get(expectedURL, { status: 200 });
 
       await fetch.get(TARGET_URL, {
-        searchParams: { test: 'encode this&' },
+        query: { test: 'encode this&' },
       });
 
       expect(sandbox.done()).to.be.true;

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -69,7 +69,7 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
 
   private createMethod(method: HTTPMethod) {
     return (url: string | Req, options?: Omit<RequestOptions<Opts>, 'method'>) => {
-      const response = this.send(url, { ...options, method } as RequestOptions<Opts>);
+      const response = this.send(url, { ...options, method } as unknown as RequestOptions<Opts>);
 
       return Object.assign(response, {
         json: async <T = unknown>(): Promise<T> => (await response).json(),

--- a/packages/fetch/src/request-options.interface.ts
+++ b/packages/fetch/src/request-options.interface.ts
@@ -3,7 +3,7 @@ import { FetchOptions } from './fetch.interface';
 export interface ExtraOptions {
   json?: any;
   headers?: Record<string, string> | Map<string, string>;
-  searchParams?: URLSearchParams | [string, string][] | Record<string, string> | Map<string, string>;
+  query?: URLSearchParams | [string, string][] | Record<string, string> | Map<string, string> | undefined;
 }
 
 export type RequestOptions<Opts extends FetchOptions<any, any>> = Omit<Partial<Opts>, keyof ExtraOptions> & ExtraOptions;

--- a/packages/fetch/src/request-options.interface.ts
+++ b/packages/fetch/src/request-options.interface.ts
@@ -1,8 +1,9 @@
 import { FetchOptions } from './fetch.interface';
 
-interface ExtraOptions {
+export interface ExtraOptions {
   json?: any;
   headers?: Record<string, string> | Map<string, string>;
+  searchParams?: URLSearchParams | [string, string][] | Record<string, string> | Map<string, string>;
 }
 
 export type RequestOptions<Opts extends FetchOptions<any, any>> = Omit<Partial<Opts>, keyof ExtraOptions> & ExtraOptions;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Support for passing `searchParams` as an option, which adds `URLSearchParams` to the requested URL.

```ts
const fetch = new FetchClient();
await fetch.get('https://google.com', {
  searchParams: { a: 1, b: 2 }
});
// GET https://google.com?a=1&b=2
```