### PR TITLE
[Merged by Bors] - fix: add optional platform property on card v2 (PL-102)

### DIFF
--- a/packages/base-types/src/node/cardV2.ts
+++ b/packages/base-types/src/node/cardV2.ts
@@ -45,6 +45,7 @@ type CardDataWithGeneralButton = CardV2Data<GeneralRequestButton | ActionRequest
 export interface Node extends BaseNode, NodeNextID, BaseNoReplyNodeData, BaseNoMatchNodeData, CardDataWithGeneralButton {
   type: NodeType.CARD_V2;
   isBlocking: boolean;
+  platform?: string;
 }
 
 export interface TraceCardV2Description {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-102**

### Brief description. What is this change?
When creating the cardV2 type we forgot to add the platform, similarly to what we have on other nodes.

This is a step in-between to get the all the runtimes merged together

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
