### PR TITLE
[Merged by Bors] - fix: update api-key model (PL-000)

### DIFF
--- a/packages/api-sdk/src/resources/apiKey.ts
+++ b/packages/api-sdk/src/resources/apiKey.ts
@@ -21,7 +21,7 @@ class APIKeyResource extends CrudResource<BaseModels.ApiKey.Model, ModelIDKey, A
     return super._getByID<BaseModels.ApiKey.Model>(id);
   }
 
-  public async create(workspaceID: string, body: Partial<BaseModels.ApiKey.Model>): Promise<BaseModels.ApiKey.Model & { APIKey: string }> {
+  public async create(workspaceID: string, body: Partial<BaseModels.ApiKey.Model>): Promise<BaseModels.ApiKey.Model & { key: string }> {
     return super._post({ ...body, workspaceID } as any);
   }
 

--- a/packages/api-sdk/src/resources/project/index.ts
+++ b/packages/api-sdk/src/resources/project/index.ts
@@ -129,6 +129,12 @@ class ProjectResource extends CrudResource<BaseModels.Project.Model<AnyRecord, A
 
     return data;
   }
+
+  public async getAPIKeys(id: string): Promise<BaseModels.ApiKey.Model[]> {
+    const { data } = await this.fetch.get<BaseModels.ApiKey.Model[]>(`${this._getCRUDEndpoint(id)}/api-keys`);
+
+    return data;
+  }
 }
 
 export default ProjectResource;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-000**

### Brief description. What is this change?
referencing code from creator-app, it seems like the conventions have changed. We should move the functionality to `listAPIKeys` to the SDK instead.
https://github.com/voiceflow/creator-app/blob/ccb1fdc9fcd9c4f123011dcbd789256dc9c40fde/packages/creator-app/src/client/project.ts#L7-L27

Also it seems like on the frontend we rely on getting back a `key` for unencrypted keys (DM API keys)
https://github.com/voiceflow/creator-app/blob/86b72785cf2acd8a0cc7bac60a334d5bc1d5dadf/packages/creator-app/src/models/ProjectAPIKey.ts#L3

This is supported by `creator-api`:
https://github.com/voiceflow/creator-api/blob/af64e7ab1680769028c253318089d282e468831f/lib/models/apiKey/index.ts#L115
