### PR TITLE
[Merged by Bors] - feat: add global fetch headers (DX-261)

### DIFF
--- a/packages/fetch/src/client-configuration.interface.ts
+++ b/packages/fetch/src/client-configuration.interface.ts
@@ -1,3 +1,6 @@
-export interface ClientConfiguration {
+import { RequestHeaders } from './request-options.interface';
+
+export interface ClientConfiguration<Headers> {
   baseURL?: string;
+  headers?: RequestHeaders;
 }

--- a/packages/fetch/src/client-configuration.interface.ts
+++ b/packages/fetch/src/client-configuration.interface.ts
@@ -1,6 +1,6 @@
 import { RequestHeaders } from './request-options.interface';
 
-export interface ClientConfiguration<Headers> {
+export interface ClientConfiguration {
   baseURL?: string;
   headers?: RequestHeaders;
 }

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -3,19 +3,15 @@ import { ClientException } from '@voiceflow/exception';
 import { ClientConfiguration } from './client-configuration.interface';
 import { FetchAPI, FetchOptions, FetchResponse } from './fetch.interface';
 import { HTTPMethod } from './http-method.enum';
-import { ExtraOptions, RequestOptions } from './request-options.interface';
+import { RequestHeaders, RequestOptions, RequestQuery } from './request-options.interface';
 
 export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req = URL | Request, Res extends FetchResponse = Response> {
-  private static extractHeaders(headers: ExtraOptions['headers']) {
-    if (headers instanceof Map) return new Map(headers);
-
-    return new Map(Object.entries(headers ?? {}));
+  private static extractHeaders(headers: RequestHeaders | undefined) {
+    return new Map(headers instanceof Map ? headers : Object.entries(headers ?? {}));
   }
 
-  private static extractQuery(query: ExtraOptions['query']) {
-    if (query instanceof Map) return new URLSearchParams(Object.entries(query));
-
-    return new URLSearchParams(query);
+  private static extractQuery(query: RequestQuery | undefined) {
+    return new URLSearchParams(query instanceof Map ? Object.entries(query) : query);
   }
 
   private static formatURL(baseURL: string | undefined, path: string, query: URLSearchParams) {
@@ -24,14 +20,14 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
     return url.href;
   }
 
-  private readonly config: ClientConfiguration;
+  private readonly config: ClientConfiguration<Headers>;
 
   private readonly fetch: FetchAPI<Opts, Req, Res> | undefined;
 
   /* eslint-disable lines-between-class-members */
-  constructor(config?: ClientConfiguration);
-  constructor(fetch: FetchAPI<Opts, Req, Res>, options?: ClientConfiguration);
-  constructor(fetchOrConfig?: FetchAPI<Opts, Req, Res> | ClientConfiguration, config?: ClientConfiguration) {
+  constructor(config?: ClientConfiguration<Headers>);
+  constructor(fetch: FetchAPI<Opts, Req, Res>, options?: ClientConfiguration<Headers>);
+  constructor(fetchOrConfig?: FetchAPI<Opts, Req, Res> | ClientConfiguration<Headers>, config?: ClientConfiguration<Headers>) {
     if (typeof fetchOrConfig === 'function') {
       this.fetch = fetchOrConfig;
       this.config = config ?? {};
@@ -45,8 +41,8 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
     // eslint-disable-next-line prefer-const
     let { json, headers, query, body, ...options } = rawOptions;
 
-    headers = new Map(headers && FetchClient.extractHeaders(headers));
-    query = new URLSearchParams(query && FetchClient.extractQuery(query));
+    headers = new Map([...FetchClient.extractHeaders(this.config.headers).entries(), ...FetchClient.extractHeaders(headers).entries()]);
+    query = FetchClient.extractQuery(query);
 
     if (json != null) {
       headers.set('content-type', 'application/json');

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -20,14 +20,14 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
     return url.href;
   }
 
-  private readonly config: ClientConfiguration<Headers>;
+  private readonly config: ClientConfiguration;
 
   private readonly fetch: FetchAPI<Opts, Req, Res> | undefined;
 
   /* eslint-disable lines-between-class-members */
-  constructor(config?: ClientConfiguration<Headers>);
-  constructor(fetch: FetchAPI<Opts, Req, Res>, options?: ClientConfiguration<Headers>);
-  constructor(fetchOrConfig?: FetchAPI<Opts, Req, Res> | ClientConfiguration<Headers>, config?: ClientConfiguration<Headers>) {
+  constructor(config?: ClientConfiguration);
+  constructor(fetch: FetchAPI<Opts, Req, Res>, options?: ClientConfiguration);
+  constructor(fetchOrConfig?: FetchAPI<Opts, Req, Res> | ClientConfiguration, config?: ClientConfiguration) {
     if (typeof fetchOrConfig === 'function') {
       this.fetch = fetchOrConfig;
       this.config = config ?? {};

--- a/packages/fetch/src/request-options.interface.ts
+++ b/packages/fetch/src/request-options.interface.ts
@@ -1,9 +1,13 @@
 import { FetchOptions } from './fetch.interface';
 
+export type RequestHeaders = Record<string, string> | Map<string, string>;
+
+export type RequestQuery = URLSearchParams | [string, string][] | Record<string, string> | Map<string, string>;
+
 export interface ExtraOptions {
   json?: any;
-  headers?: Record<string, string> | Map<string, string>;
-  query?: URLSearchParams | [string, string][] | Record<string, string> | Map<string, string> | undefined;
+  headers?: RequestHeaders;
+  query?: RequestQuery | undefined;
 }
 
 export type RequestOptions<Opts extends FetchOptions<any, any>> = Omit<Partial<Opts>, keyof ExtraOptions> & ExtraOptions;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-261**

### Brief description. What is this change?

Add `headers` config when constructing the `FetchClient` which can be updated asynchronously

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
