### PR TITLE
fix: base response trace with ai indicator (PL-000)

### DIFF
--- a/packages/base-types/src/node/speak.ts
+++ b/packages/base-types/src/node/speak.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '@voiceflow/common';
 
 import { NodeType } from './constants';
-import { BaseNode, BaseStep, BaseTraceFrame, NodeNextID, StepCanvasNodeVisibility, TraceType } from './utils';
+import { BaseNode, BaseResponseTrace, BaseStep, BaseTraceFrame, NodeNextID, StepCanvasNodeVisibility, TraceType } from './utils';
 
 export interface StepDataDialog<Dialog> {
   dialogs: Dialog[];
@@ -32,11 +32,10 @@ export enum TraceSpeakType {
   MESSAGE = 'message',
 }
 
-export interface TraceFramePayload {
+export interface TraceFramePayload extends BaseResponseTrace {
   src?: Nullable<string>;
   type: TraceSpeakType;
   voice?: string;
-  message: string;
 }
 
 export interface TraceFrame extends BaseTraceFrame<TraceFramePayload> {

--- a/packages/base-types/src/node/text.ts
+++ b/packages/base-types/src/node/text.ts
@@ -1,7 +1,7 @@
 import { SlateTextValue } from '@base-types/text';
 
 import { NodeType } from './constants';
-import { BaseNode, BaseStep, BaseTraceFrame, DataID, NodeNextID, StepCanvasNodeVisibility, TraceType } from './utils';
+import { BaseNode, BaseResponseTrace, BaseStep, BaseTraceFrame, DataID, NodeNextID, StepCanvasNodeVisibility, TraceType } from './utils';
 
 export interface TextData extends DataID {
   content: SlateTextValue;
@@ -22,8 +22,7 @@ export interface Node extends BaseNode, NodeNextID {
   platform?: string;
 }
 
-export interface TextTracePayload {
-  message: string;
+export interface TextTracePayload extends BaseResponseTrace {
   slate: TextData;
 }
 

--- a/packages/base-types/src/node/utils/trace.ts
+++ b/packages/base-types/src/node/utils/trace.ts
@@ -31,3 +31,8 @@ export interface BaseTraceFrame<Payload = any, TracePath extends BaseTraceFrameP
   payload: Payload;
   defaultPath?: number;
 }
+
+export interface BaseResponseTrace {
+  ai?: boolean;
+  message: string;
+}


### PR DESCRIPTION
both speak and text traces should have a `message: string` property.

added a new optional `ai?: boolean` indicator to dictate if the response is freely generated