### PR TITLE
[Merged by Bors] - feat: configure default messages for no-match and no-reply (CT-1384)

### DIFF
--- a/packages/voiceflow-types/src/constants/index.ts
+++ b/packages/voiceflow-types/src/constants/index.ts
@@ -2,5 +2,6 @@ export * from './azureVoices';
 export * from './base';
 export * from './device';
 export * from './intent';
+export * from './messages';
 export * from './platformType';
 export * from './slot';

--- a/packages/voiceflow-types/src/constants/messages.ts
+++ b/packages/voiceflow-types/src/constants/messages.ts
@@ -1,0 +1,4 @@
+export const defaultMessages = {
+  globalNoReply: 'Are you still there?',
+  globalNoMatch: 'Sorry, I didn’t get that. Please try again',
+};


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1384**

### Brief description. What is this change?

Configure default messages for global no-reply and global no-match.
