### PR TITLE
[Merged by Bors] - feat: added method for new training receipt endpoint (PL-430)

### DIFF
--- a/packages/api-sdk/src/resources/project/index.ts
+++ b/packages/api-sdk/src/resources/project/index.ts
@@ -117,6 +117,15 @@ class ProjectResource extends CrudResource<BaseModels.Project.Model<AnyRecord, A
     return data;
   }
 
+  public async updateDevTrainingReceipt<P extends BaseModels.Project.Prototype>(
+    id: string,
+    trainingReceipt: Pick<Required<BaseModels.Project.Prototype>, 'lastTrainedTime' | 'trainedModel'>
+  ): Promise<P> {
+    const { data } = await this.fetch.patch<P>(`${this._getCRUDEndpoint(id)}/prototype/training-receipt`, trainingReceipt);
+
+    return data;
+  }
+
   public async getCreator<
     P extends BaseModels.Project.Model<any, any> = BaseModels.Project.Model<AnyRecord, AnyRecord>,
     V extends BaseModels.Version.Model<any, any, string> = BaseModels.Version.Model<BaseModels.Version.PlatformData>,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-430**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Added method to `creator-api` wrapper for new endpoint that updates the training receipt in the `prototype` (not any other property in `prototype`). Please see the `creator-api` PR in the Related PRs for full context.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Added a new method to the `api-sdk` that calls the new endpoint in `creator-api`. 

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/libs/pull/418
- https://github.com/voiceflow/creator-api/pull/1177

The changes in this PR are used by `general-service` changes here:
- https://github.com/voiceflow/general-service/pull/475

### Checklist

- [x] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- ~~[ ] appropriate tests have been written~~
- ~~[ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified~~
