### PR TITLE
[Merged by Bors] - fix: generate step (CT-000)

### DIFF
--- a/packages/base-types/src/models/project/index.ts
+++ b/packages/base-types/src/models/project/index.ts
@@ -26,8 +26,10 @@ export interface Sticker {
 }
 
 export interface AIAssistSettings {
+  freestyle?: boolean /** @deprecated in favor of generate no match */;
+  generateStep?: boolean;
+  generateNoMatch?: boolean;
   generativeTasks?: boolean;
-  freestyle?: boolean;
 }
 
 export interface Model<PlatformData extends AnyRecord, MemberPlatformData extends AnyRecord> {


### PR DESCRIPTION
We're doing a switchover from `freestyle` to `generateNoMatch`

added `generateStep` property