### PR TITLE
[Merged by Bors] - fix: add delay property to text trace (PL-000)

### DIFF
--- a/packages/base-types/src/node/text.ts
+++ b/packages/base-types/src/node/text.ts
@@ -5,6 +5,7 @@ import { BaseNode, BaseResponseTrace, BaseStep, BaseTraceFrame, DataID, NodeNext
 
 export interface TextData extends DataID {
   content: SlateTextValue;
+  /** @deprecated use TextTracePayload.delay instead */
   messageDelayMilliseconds?: number;
 }
 
@@ -24,6 +25,7 @@ export interface Node extends BaseNode, NodeNextID {
 
 export interface TextTracePayload extends BaseResponseTrace {
   slate: TextData;
+  delay?: number;
 }
 
 export interface TraceFrame extends BaseTraceFrame<TextTracePayload> {


### PR DESCRIPTION
moving `payload.slate.messageDelayMilliseconds` to just a `payload.delay` field:
```
BEFORE TRACE {
  type: "text",
  payload: {
    slate: { ...blah, messageDelayMilliseconds: 1000 },
    message: "hello",
  }
}
```

```
AFTER TRACE {
  type: "text",
  payload: {
    delay: 1000,
    slate: { ...blah },
    message: "hello",
  }
}
```

It makes more sense to be top level instead of nested inside a unknown slate property. This is still backwards compatible. 