### PR TITLE
[Merged by Bors] - fix: uppercase method names to fix unidici PATCH requests (DX-000)

### DIFF
--- a/packages/fetch/src/fetch.client.test.ts
+++ b/packages/fetch/src/fetch.client.test.ts
@@ -197,7 +197,7 @@ describe('Fetch Client', () => {
 
       await fetchClient.get(url);
 
-      expect(fetchSpy).to.be.calledWithExactly(url, { method: 'get', headers: {}, body: undefined });
+      expect(fetchSpy).to.be.calledWithExactly(url, { method: 'GET', headers: {}, body: undefined });
     });
   });
 

--- a/packages/fetch/src/fetch.client.ts
+++ b/packages/fetch/src/fetch.client.ts
@@ -65,7 +65,7 @@ export class FetchClient<Opts extends FetchOptions<any, any> = RequestInit, Req 
 
   private createMethod(method: HTTPMethod) {
     return (url: string | Req, options?: Omit<RequestOptions<Opts>, 'method'>) => {
-      const response = this.send(url, { ...options, method } as RequestOptions<Opts>);
+      const response = this.send(url, { ...options, method: method.toUpperCase() } as RequestOptions<Opts>);
 
       return Object.assign(response, {
         json: async <T = unknown>(): Promise<T> => (await response).json(),


### PR DESCRIPTION
### Brief description. What is this change?

If we use `patch` instead of `PATCH` then undici fails immediately with a `400` status code and never establishes a connection with the remove server... very cool

https://github.com/sveltejs/kit/issues/5380

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test