### PR TITLE
[Merged by Bors] - feat: global generative no match (LLM-001)

### DIFF
--- a/packages/base-types/src/version/settings.ts
+++ b/packages/base-types/src/version/settings.ts
@@ -1,4 +1,5 @@
 import { CarouselLayout } from '@base-types/node/carousel';
+import { AIModelParams } from '@base-types/utils/ai';
 import { Nullable } from '@voiceflow/common';
 
 import { Utils } from '../node';
@@ -26,6 +27,11 @@ export interface ResumeSession<Prompt = unknown> {
 
 export type Session<Prompt = unknown> = RestartSession | ResumeSession<Prompt>;
 
+export enum GlobalNoMatchType {
+  STATIC = 'static',
+  GENERATIVE = 'generative',
+}
+
 export interface Settings<Prompt = unknown> {
   error: Nullable<Prompt>;
   repeat: RepeatType;
@@ -38,9 +44,15 @@ export interface Settings<Prompt = unknown> {
     delay?: number | undefined;
   };
 
-  globalNoMatch?: {
-    prompt?: Nullable<Prompt> | undefined;
-  };
+  globalNoMatch?:
+    | {
+        type: GlobalNoMatchType.STATIC;
+        prompt: Nullable<Prompt> | undefined;
+      }
+    | {
+        type: GlobalNoMatchType.GENERATIVE;
+        prompt: AIModelParams;
+      };
 }
 
 export const defaultSettings = <Prompt>({
@@ -50,7 +62,7 @@ export const defaultSettings = <Prompt>({
   defaultCanvasNodeVisibility = null,
   defaultCarouselLayout = null,
 
-  globalNoMatch = { prompt: undefined },
+  globalNoMatch = { type: GlobalNoMatchType.STATIC, prompt: undefined },
   globalNoReply = { delay: undefined, prompt: undefined },
 }: Partial<Settings<Prompt>> = {}): Settings<Prompt> => ({
   error,


### PR DESCRIPTION
We're going to enable an option for AI global no-match configurations.
![Screenshot 2023-05-17 at 3 16 26 PM](https://github.com/voiceflow/libs/assets/5643574/f269b6f2-74b8-482d-b786-35fe60fc84a9)

The other tab would just look something like this:
![Screenshot 2023-05-17 at 3 17 05 PM](https://github.com/voiceflow/libs/assets/5643574/73f2e031-1aa8-4ffc-bf8c-dd20abae4c8c)

We're going to use the FE migrations to ensure the types are set