### PR TITLE
[Merged by Bors] - feat: add ai prop to TextTracePayload (CT-2052)

### DIFF
--- a/packages/base-types/src/node/text.ts
+++ b/packages/base-types/src/node/text.ts
@@ -26,6 +26,7 @@ export interface Node extends BaseNode, NodeNextID {
 export interface TextTracePayload extends BaseResponseTrace {
   slate: TextData;
   delay?: number;
+  ai?: boolean;
 }
 
 export interface TraceFrame extends BaseTraceFrame<TextTracePayload> {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-2052**

### Brief description. What is this change?

Add `ai` optional property to `TextTracePayload`.
This will be used in the react-chat to tell which messages are generated from ai.
We need this now specifically for TICO's feedback feature.
