### PR TITLE
[Merged by Bors] - fix: make diagramID optional for diagram model (VF-000)

### DIFF
--- a/packages/base-types/src/models/diagram.ts
+++ b/packages/base-types/src/models/diagram.ts
@@ -20,7 +20,7 @@ export interface MenuItem {
 export interface Model<Node extends BaseDiagramNode = BaseDiagramNode> {
   _id: string;
   versionID: string;
-  diagramID: string;
+  diagramID?: string;
   creatorID: number;
 
   name: string;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

- diagramID as required is breaking services that we didn't update yet. To not block people, we are going to make it optional until we update all the services.

