### PR TITLE
[Merged by Bors] - feat: add new programs and diagrams endpoint under version (CV3-389)

### DIFF
--- a/packages/api-sdk/src/resources/version/diagram.ts
+++ b/packages/api-sdk/src/resources/version/diagram.ts
@@ -1,0 +1,25 @@
+import Fetch from '@api-sdk/fetch';
+import { BaseModels } from '@voiceflow/base-types';
+
+import CrudNestedResource from '../crudNested';
+
+const ENDPOINT = 'diagrams';
+
+export type ModelKey = 'diagramID';
+
+class DiagramResource extends CrudNestedResource<string, BaseModels.Diagram.Model, ModelKey, DiagramResource> {
+  constructor(fetch: Fetch, { parentEndpoint }: { parentEndpoint: string }) {
+    super({
+      fetch,
+      clazz: DiagramResource,
+      endpoint: ENDPOINT,
+      clazzOptions: { parentEndpoint },
+    });
+  }
+
+  public async get(versionID: string, diagramID: string): Promise<BaseModels.Diagram.Model> {
+    return this._getByID<BaseModels.Diagram.Model>(versionID, diagramID);
+  }
+}
+
+export default DiagramResource;

--- a/packages/api-sdk/src/resources/version/index.ts
+++ b/packages/api-sdk/src/resources/version/index.ts
@@ -5,7 +5,10 @@ import { AnyRecord } from '@voiceflow/common';
 import { Fields } from '../base';
 import CrudResource from '../crud';
 import CanvasTemplate from './canvasTemplate';
+import Diagram from './diagram';
 import Domain from './domain';
+import Program from './program';
+import PrototypeProgram from './prototypeProgram';
 
 export const ENDPOINT = 'versions';
 
@@ -16,6 +19,12 @@ class VersionResource extends CrudResource<BaseModels.Version.Model<BaseModels.V
 
   public canvasTemplate: CanvasTemplate;
 
+  public program: Program;
+
+  public prototypeProgram: PrototypeProgram;
+
+  public diagram: Diagram;
+
   constructor(fetch: Fetch) {
     super({
       fetch,
@@ -25,6 +34,9 @@ class VersionResource extends CrudResource<BaseModels.Version.Model<BaseModels.V
 
     this.domain = new Domain(fetch, { parentEndpoint: ENDPOINT });
     this.canvasTemplate = new CanvasTemplate(fetch, { parentEndpoint: ENDPOINT });
+    this.program = new Program(fetch, { parentEndpoint: ENDPOINT });
+    this.prototypeProgram = new PrototypeProgram(fetch, { parentEndpoint: ENDPOINT });
+    this.diagram = new Diagram(fetch, { parentEndpoint: ENDPOINT });
   }
 
   public async get<T extends Partial<BaseModels.Version.Model<BaseModels.Version.PlatformData>>>(id: string, fields: Fields): Promise<T>;

--- a/packages/api-sdk/src/resources/version/program.ts
+++ b/packages/api-sdk/src/resources/version/program.ts
@@ -1,0 +1,25 @@
+import Fetch from '@api-sdk/fetch';
+import { BaseModels } from '@voiceflow/base-types';
+
+import CrudNestedResource from '../crudNested';
+
+const ENDPOINT = 'programs';
+
+export type ModelKey = 'diagramID';
+
+class ProgramResource extends CrudNestedResource<string, BaseModels.Program.Model, ModelKey, ProgramResource> {
+  constructor(fetch: Fetch, { parentEndpoint }: { parentEndpoint: string }) {
+    super({
+      fetch,
+      clazz: ProgramResource,
+      endpoint: ENDPOINT,
+      clazzOptions: { parentEndpoint },
+    });
+  }
+
+  public async get(versionID: string, diagramID: string): Promise<BaseModels.Program.Model> {
+    return this._getByID<BaseModels.Program.Model>(versionID, diagramID);
+  }
+}
+
+export default ProgramResource;

--- a/packages/api-sdk/src/resources/version/prototypeProgram.ts
+++ b/packages/api-sdk/src/resources/version/prototypeProgram.ts
@@ -1,0 +1,25 @@
+import Fetch from '@api-sdk/fetch';
+import { BaseModels } from '@voiceflow/base-types';
+
+import CrudNestedResource from '../crudNested';
+
+const ENDPOINT = 'prototype-programs';
+
+export type ModelKey = 'diagramID';
+
+class PrototypeProgramResource extends CrudNestedResource<string, BaseModels.Program.Model, ModelKey, PrototypeProgramResource> {
+  constructor(fetch: Fetch, { parentEndpoint }: { parentEndpoint: string }) {
+    super({
+      fetch,
+      clazz: PrototypeProgramResource,
+      endpoint: ENDPOINT,
+      clazzOptions: { parentEndpoint },
+    });
+  }
+
+  public async get(versionID: string, diagramID: string): Promise<BaseModels.Program.Model> {
+    return this._getByID<BaseModels.Program.Model>(versionID, diagramID);
+  }
+}
+
+export default PrototypeProgramResource;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CV3-389**

### Brief description. What is this change?
 - These new endpoints will be used by general-service to read diagrams and programs

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test