### PR TITLE
[Merged by Bors] - feat: KB type models add `KBTags` (NLU-864)

### DIFF
--- a/packages/base-types/src/models/project/knowledgeBase.ts
+++ b/packages/base-types/src/models/project/knowledgeBase.ts
@@ -7,6 +7,23 @@ export enum KnowledgeBaseDocumentType {
   DOCX = 'docx',
 }
 
+export declare enum KnowledgeBaseBooleanOperators {
+  AND = 'and',
+  OR = 'or',
+}
+
+export interface KnowledgeBaseTagsInclude {
+  items: string[];
+  operator?: KnowledgeBaseBooleanOperators;
+}
+
+export interface KnowledgeBaseTagsFilter {
+  include?: KnowledgeBaseTagsInclude;
+  exclude?: string[];
+  includeAllTagged?: boolean;
+  includeAllNonTagged?: boolean;
+}
+
 export interface KnowledgeBaseData {
   type: KnowledgeBaseDocumentType;
   name: string;
@@ -40,6 +57,11 @@ export enum KnowledgeBaseDocumentStatus {
   INITIALIZED = 'INITIALIZED',
 }
 
+export interface KBTag {
+  tagID: string;
+  label: string;
+}
+
 export interface KnowledgeBaseDocument {
   data: KnowledgeBasePDF | KnowledgeBaseText | KnowledgeBaseURL | KnowledgeBaseDocx;
   status: {
@@ -51,6 +73,7 @@ export interface KnowledgeBaseDocument {
   documentID: string;
   s3ObjectRef: string;
   version?: number;
+  tags?: string[];
 }
 
 export enum ChunkStrategyType {
@@ -75,4 +98,5 @@ export interface KnowledgeBaseSettings {
 export interface KnowledgeBase {
   settings?: KnowledgeBaseSettings;
   documents: Record<string, KnowledgeBaseDocument>;
+  tags?: Record<string, KBTag>;
 }


### PR DESCRIPTION
### Brief description. What is this change?

Add `KBTag` to KB models.

### Implementation details. How do you make this change?

We plan to add tags to KB documents to filter by them. The work will be similar to how `transcripts` and adding tags work now. For this purpose, an entity called `KBTag` was added.

References to this entity have been added to the `KnowledgeBase` and `KnowledgeBaseDocument` entities:

* `KnowledgeBase` - the link here is all available tags in the current KB that can be used to attach to documents;
* `KnowledgeBaseDocument` - this is a list of tags associated with a specific document.

### Setup information

N/A

### Deployment Notes

N/A

### Related Jira ticket

* [NLU-864](https://voiceflow.atlassian.net/browse/NLU-864)


[NLU-864]: https://voiceflow.atlassian.net/browse/NLU-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Related PRs

- https://github.com/voiceflow/creator-api/pull/1315
- https://github.com/voiceflow/database-cli/pull/455
- https://github.com/voiceflow/general-runtime/pull/598