### PR TITLE
[Merged by Bors] - feat: add exclution operator logic (NLU-864)

### DIFF
--- a/packages/base-types/src/models/project/knowledgeBase.ts
+++ b/packages/base-types/src/models/project/knowledgeBase.ts
@@ -12,14 +12,14 @@ export declare enum KnowledgeBaseBooleanOperators {
   OR = 'or',
 }
 
-export interface KnowledgeBaseTagsInclude {
+export interface KnowledgeBaseTagsFilterWithOperator {
   items: string[];
   operator?: KnowledgeBaseBooleanOperators;
 }
 
 export interface KnowledgeBaseTagsFilter {
-  include?: KnowledgeBaseTagsInclude;
-  exclude?: string[];
+  include?: KnowledgeBaseTagsFilterWithOperator;
+  exclude?: KnowledgeBaseTagsFilterWithOperator;
   includeAllTagged?: boolean;
   includeAllNonTagged?: boolean;
 }


### PR DESCRIPTION
### Brief description. What is this change?

Extend exclude field with option to provide condition operator

### Implementation details. How do you make this change?

We make an exclude field in the tags filter in the same format as include. The main reason to make these fields identical in their structure is to avoid confusion for our users

How it should work:

Let's say we have a document with such a list of tags: `["tag1", "tag2", "tag3"]`

* Case 1: `{"tags": {"includeAllTagged": true, "exclude": {"items": ["tag1", "tag5"], "operator": "or"}}}`:

This query should not return this document, because it is enough for at least one of the elements in `exclude.items` to be in documents to skip it

* Case 1: `{"tags": {"includeAllTagged": true, "exclude": {"items": ["tag1", "tag5"], "operator": "and"}}}`:

This query should return a document because the document does not have `tag5` and the query only bars documents that have both `tag1 AND tag5`

**_# NOTE:_** need to update `general-runtime` `base-types` libs version for apply that changes

### Related PRs

* https://github.com/voiceflow/KnowledgeLake/pull/165

### Development Notes:

- [ ] Don't merge before update `KnowledgeLake` side

### Checklist

- [X] Make changes in existing tags filters tests
- [X] Test logic in dev env