### PR TITLE
[Merged by Bors] - feat: remove api-sdk diagram get by id (CV3-533)

### DIFF
--- a/packages/api-sdk/src/resources/diagram.ts
+++ b/packages/api-sdk/src/resources/diagram.ts
@@ -1,7 +1,6 @@
 import type Fetch from '@api-sdk/fetch';
 import { BaseModels } from '@voiceflow/base-types';
 
-import { Fields } from './base';
 import CrudResource from './crud';
 
 const ENDPOINT = 'diagrams';
@@ -16,16 +15,6 @@ class DiagramResource extends CrudResource<BaseModels.Diagram.Model, ModelIDKey,
       clazz: DiagramResource,
       endpoint: ENDPOINT,
     });
-  }
-
-  public async get<T extends Partial<BaseModels.Diagram.Model>>(id: string, fields: Fields): Promise<T>;
-
-  public async get<T extends BaseModels.BaseDiagramNode = BaseModels.BaseDiagramNode>(id: string): Promise<BaseModels.Diagram.Model<T>>;
-
-  public async get<T extends BaseModels.Diagram.Model<any> = BaseModels.Diagram.Model>(id: string): Promise<T>;
-
-  public async get(id: string, fields?: Fields): Promise<BaseModels.Diagram.Model<any>> {
-    return fields ? super._getByID(id, fields) : super._getByID(id);
   }
 
   public async getRTC<T extends BaseModels.Diagram.Model<any> = BaseModels.Diagram.Model>(id: string): Promise<{ diagram: T; timestamp: number }> {

--- a/packages/api-sdk/tests/resources/diagram.unit.ts
+++ b/packages/api-sdk/tests/resources/diagram.unit.ts
@@ -45,30 +45,6 @@ describe('DiagramResource', () => {
     sinon.restore();
   });
 
-  it('.get', async () => {
-    const { crud, resource } = createClient();
-
-    crud.getByID.resolves(RESPONSE_DATA);
-
-    const data = await resource.get('1');
-
-    expect(crud.getByID.callCount).to.eql(1);
-    expect(crud.getByID.args[0]).to.eql(['1']);
-    expect(data).to.eql(RESPONSE_DATA);
-  });
-
-  it('.get fields', async () => {
-    const { crud, resource } = createClient();
-
-    crud.getByID.resolves(RESPONSE_DATA);
-
-    const data = await resource.get('1', ['name', 'zoom', 'offsetX']);
-
-    expect(crud.getByID.callCount).to.eql(1);
-    expect(crud.getByID.args[0]).to.eql(['1', ['name', 'zoom', 'offsetX']]);
-    expect(data).to.eql(RESPONSE_DATA);
-  });
-
   it('.getRTC', async () => {
     const { fetch, resource } = createClient();
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CV3-533**

### Brief description. What is this change?

We are not going to allow fetching diagrams by _id anymore.

Diagrams need to be fetched using versionID and diagramID through version endpoint

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test