### PR TITLE
[Merged by Bors] - feat: add canEdit field to KB doc (VF-000)

### DIFF
--- a/packages/base-types/src/models/project/knowledgeBase.ts
+++ b/packages/base-types/src/models/project/knowledgeBase.ts
@@ -67,6 +67,7 @@ export interface KnowledgeBaseDocument {
   status: {
     type: KnowledgeBaseDocumentStatus;
     data?: unknown;
+    canEdit?: boolean;
   };
   creatorID: number;
   updatedAt: Date;

--- a/packages/base-types/src/models/project/knowledgeBase.ts
+++ b/packages/base-types/src/models/project/knowledgeBase.ts
@@ -42,6 +42,7 @@ export interface KnowledgeBaseDocx extends KnowledgeBaseData {
 export interface KnowledgeBaseText extends KnowledgeBaseData {
   type: KnowledgeBaseDocumentType.TEXT;
   name: string;
+  canEdit?: boolean;
 }
 
 export interface KnowledgeBaseURL extends KnowledgeBaseData {
@@ -67,7 +68,6 @@ export interface KnowledgeBaseDocument {
   status: {
     type: KnowledgeBaseDocumentStatus;
     data?: unknown;
-    canEdit?: boolean;
   };
   creatorID: number;
   updatedAt: Date;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CV3-588**

### Brief description. What is this change?

Add a canEdit field to the status object on the KB document.
This is differentiate between a plain text kb object where the text is editable and a TXT file upload which cannot be edited. 