### PR TITLE
feat: new function step type (CV3-617)

### DIFF
--- a/packages/base-types/src/markup/index.ts
+++ b/packages/base-types/src/markup/index.ts
@@ -1,0 +1,14 @@
+export interface VariableReference {
+  variableID: string;
+}
+export interface EntityReference {
+  entityID: string;
+}
+export interface MarkupSpan {
+  attributes: Record<string, unknown>;
+  text: Markup;
+}
+
+export type MarkupNode = string | MarkupSpan | VariableReference | EntityReference;
+
+export type Markup = Array<MarkupNode>;

--- a/packages/base-types/src/models/base/port.ts
+++ b/packages/base-types/src/models/base/port.ts
@@ -1,6 +1,7 @@
 import { EmptyObject, Nullable } from '@voiceflow/common';
 
 export enum PortType {
+  FUNCTION = 'function',
   FAIL = 'fail',
   NEXT = 'next',
   PAUSE = 'pause',

--- a/packages/base-types/src/node/constants.ts
+++ b/packages/base-types/src/node/constants.ts
@@ -44,6 +44,7 @@ export enum NodeType {
   TRACE = 'trace',
   CHANNEL_ACTION = 'channel_action',
   CUSTOM_BLOCK_POINTER = 'custom_block_pointer',
+  FUNCTION = 'function',
 
   // other
   URL = 'url',

--- a/packages/base-types/src/node/function.ts
+++ b/packages/base-types/src/node/function.ts
@@ -1,0 +1,129 @@
+import { Markup } from '@base-types/markup';
+import { PortType } from '@base-types/models';
+
+import { NodeType } from './constants';
+import { BaseNode, BasePort, BaseStep, EmptyStepPorts } from './utils';
+
+/// ////////////////////////// DESIGN-TIME STEP /////////////////////////////
+
+export interface FunctionPort extends BasePort {
+  type: PortType.FUNCTION;
+}
+
+export interface StepPorts extends EmptyStepPorts {
+  byKey: Record<string, FunctionPort>;
+}
+
+export interface StepData {
+  /**
+   * ID of the Function resource pointed to by this Function step.
+   */
+  functionID: string | null;
+
+  /**
+   * Mapping of input variable name to input variable value
+   */
+  inputMapping: Record<string, Markup>;
+
+  /**
+   * Mapping of output variable name to output variable value
+   */
+  outputMapping: Record<string, string | null>;
+}
+
+export interface Step extends BaseStep<StepData, StepPorts> {
+  type: NodeType.FUNCTION;
+}
+
+/// ////////////////////////// COMPILE-TIME STEP /////////////////////////////
+
+export interface CompiledMarkupSpan {
+  text: CompiledMarkup;
+  attributes?: Record<string, unknown>;
+}
+
+export interface CompiledVariable {
+  /**
+   * Name of the Voiceflow variable
+   */
+  name: string;
+
+  /**
+   * ID of the Voiceflow variable
+   */
+  variableID: string;
+}
+
+export interface CompiledEntity {
+  /**
+   * Name of the entity
+   */
+  name: string;
+
+  /**
+   * ID of the entity
+   */
+  entityID: string;
+}
+
+export type CompiledMarkup = Array<string | CompiledVariable | CompiledEntity | CompiledMarkupSpan>;
+
+export enum FunctionVariableType {
+  String = 'string',
+  Number = 'number',
+  Boolean = 'boolean',
+  Array = 'array',
+  Object = 'object',
+}
+
+export interface CompiledVariableConfig {
+  /**
+   * The type of the variable.
+   *
+   * NOTE: For Functions P0, 8 Nov 2023, the type is hardcoded to be a `string`.
+   */
+  type: FunctionVariableType.String;
+}
+
+export interface CompiledFunctionData {
+  /**
+   * Actual code to be executed by the Function
+   */
+  code: string;
+
+  /**
+   * Mapping of input variable name to variable configuration
+   */
+  inputVars: Record<string, CompiledVariableConfig>;
+
+  /**
+   * Mapping of output variable name to variable configuration
+   */
+  outputVars: Record<string, CompiledVariableConfig>;
+}
+
+export interface Node extends BaseNode {
+  type: NodeType.FUNCTION;
+
+  /**
+   * Function definition
+   */
+  function: {
+    data: CompiledFunctionData;
+  };
+
+  /**
+   * Mapping of input variable name to input variable value
+   */
+  inputMapping: Record<string, CompiledMarkup>;
+
+  /**
+   * Mapping of output (Function) variable name to Voiceflow variable name
+   */
+  outputMapping: Record<string, string | null>;
+
+  /**
+   * Mapping of the Function path's "exit code" to the next step ID
+   */
+  paths: Record<string, string>;
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CV3-617**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Defining the canvas Function step and compiled Function node schemas. This PR is necessary to unblock Pedro from completing Function compilation. 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Added a type definition for a canvas Function step and a compiled Function node. 

This [section](https://www.notion.so/voiceflow/Revised-Design-Functions-fcb8f3b135614f9ca1cafd8c7da2e2ed?pvs=4#e0bd8909a34043f594b193ae7282323f) in the revised Functions design document describes the design of these type definitions.

The document includes:
1. The written copy of the type definitions
2. Examples of a canvas Function step and a compiled Function step
3. A description of how compilation and execution works

Additionally, we would like to use the new V3 CMS `Markup` format for representing text with embedded Voiceflow variables. However, there is no `Markup` type inside the `@voiceflow/base-types`. Therefore, I have defined a `Markup` type inside of `base-types`.

Additionally, I have not opted to place the Function step definition in `@voiceflow/dtos`. The reasoning is because from my perspective, there is no alignment on how we should refactor `@voiceflow/base-types` and the node & step definitions. I do not want to scatter the step/node definitions across multiple packages, which we'll have to keep track of. If a pattern is "bad", then I'd rather if the codebase was bad in a consistent way than bad in an inconsistent way. 

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

N/A

### Checklist

N/A