### PR TITLE
ci(sonar): use latest sonarcloud orb (IN-976)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -7,7 +7,7 @@ parameters:
 
 orbs:
   vfcommon: voiceflow/common@0.0.350
-  sonarcloud: sonarsource/sonarcloud@1.0.2
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 jobs:
   test:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
# **Fixes or implements IN-976**
### Brief description. What is this change?
Use latest sonarcloud orb vesrsion
