### PR TITLE
[Merged by Bors] - feat: add refresh-jobs schemas (CV3-710)

### DIFF
--- a/packages/base-types/src/models/index.ts
+++ b/packages/base-types/src/models/index.ts
@@ -4,6 +4,7 @@ export * as Diagram from './diagram';
 export * as Program from './program';
 export * as Project from './project';
 export * as ProjectSecret from './projectSecret';
+export * as RefreshRate from './refreshJob';
 export * as Transcript from './transcripts';
 export * as VariableState from './variableState';
 export * as Version from './version';

--- a/packages/base-types/src/models/index.ts
+++ b/packages/base-types/src/models/index.ts
@@ -4,7 +4,7 @@ export * as Diagram from './diagram';
 export * as Program from './program';
 export * as Project from './project';
 export * as ProjectSecret from './projectSecret';
-export * as RefreshRate from './refreshJob';
+export * as RefreshJob from './refreshJob';
 export * as Transcript from './transcripts';
 export * as VariableState from './variableState';
 export * as Version from './version';

--- a/packages/base-types/src/models/project/knowledgeBase.ts
+++ b/packages/base-types/src/models/project/knowledgeBase.ts
@@ -7,6 +7,13 @@ export enum KnowledgeBaseDocumentType {
   DOCX = 'docx',
 }
 
+export enum KnowledgeBaseDocumentRefreshRate {
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+  NEVER = 'never',
+}
+
 export declare enum KnowledgeBaseBooleanOperators {
   AND = 'and',
   OR = 'or',
@@ -75,6 +82,8 @@ export interface KnowledgeBaseDocument {
   s3ObjectRef: string;
   version?: number;
   tags?: string[];
+  refreshRate?: KnowledgeBaseDocumentRefreshRate;
+  lastSuccessUpdate?: Date;
 }
 
 export enum ChunkStrategyType {

--- a/packages/base-types/src/models/project/knowledgeBase.ts
+++ b/packages/base-types/src/models/project/knowledgeBase.ts
@@ -83,7 +83,7 @@ export interface KnowledgeBaseDocument {
   version?: number;
   tags?: string[];
   refreshRate?: KnowledgeBaseDocumentRefreshRate;
-  lastSuccessUpdate?: Date;
+  lastSuccessUpdate?: string;
 }
 
 export enum ChunkStrategyType {

--- a/packages/base-types/src/models/refreshJob.ts
+++ b/packages/base-types/src/models/refreshJob.ts
@@ -7,5 +7,5 @@ export interface Model {
   url: string;
   refreshRate: KnowledgeBaseDocumentRefreshRate;
   executeAt: Date;
-  checksum?: string;
+  checksum?: string | null;
 }

--- a/packages/base-types/src/models/refreshJob.ts
+++ b/packages/base-types/src/models/refreshJob.ts
@@ -1,6 +1,7 @@
 import { KnowledgeBaseDocumentRefreshRate } from './project/knowledgeBase';
 
 export interface Model {
+  _id: string;
   projectID: string;
   documentID: string;
   workspaceID: number;

--- a/packages/base-types/src/models/refreshJob.ts
+++ b/packages/base-types/src/models/refreshJob.ts
@@ -1,0 +1,11 @@
+import { KnowledgeBaseDocumentRefreshRate } from './project/knowledgeBase';
+
+export interface Model {
+  projectID: string;
+  documentID: string;
+  workspaceID: number;
+  url: string;
+  refreshRate: KnowledgeBaseDocumentRefreshRate;
+  executeAt: Date;
+  checksum?: string;
+}


### PR DESCRIPTION
### Brief description. What is this change?

Add new collection `refresh-jobs` and add new fields to `projects` - `refreshRates` and `lastSuccessUpdate `

### Implementation details. How do you make this change?

#### Add new collection: ***refresh-jobs***

List of fields needed to store information in this table:

- ***projectID*** - value from project
- ***documentID*** - value from project
- ***workspaceID*** - value from project
- ***checksum*** - ******is a value derived from the digital data of a file or message, generated using a specific algorithm.
- ***refreshRate*** - field for storing information about the document update frequency, possible values here are: ***daily, weekly, monthly, never.***
- ***executeAt*** - datetime object when need to run update next time.

#### Add new fields to collection: _projects_

- ***refreshRate*** - field for storing information about the document update frequency, possible values here are: ***daily, weekly, monthly, never.***
- ***lastSuccessUpdate*** - time of the last successful document update. 