### PR TITLE
[Merged by Bors] - feat: add fields `name` and `tags` to refresh-jobs (CV3-717)

### DIFF
--- a/packages/base-types/src/models/refreshJob.ts
+++ b/packages/base-types/src/models/refreshJob.ts
@@ -6,7 +6,9 @@ export interface Model {
   documentID: string;
   workspaceID: number;
   url: string;
+  name: string;
   refreshRate: KnowledgeBaseDocumentRefreshRate;
   executeAt: Date;
   checksum?: string | null;
+  tags?: string[];
 }


### PR DESCRIPTION
### Brief description. What is this change?

Add new fields _**name**_ and _**tags**_ to `refresh-jobs` mongodb model.

### Implementation details. How do you make this change?

* _**name**_ currently just a stripped url, but better to store it also in `refresh-jobs`
* _**tags**_ info need to store in VectorDB and during refresh process need also to set that value