### PR TITLE
fix: google-apis is only a dev dependency (CT-000)

### DIFF
--- a/packages/google-types/package.json
+++ b/packages/google-types/package.json
@@ -11,7 +11,9 @@
     "@voiceflow/chat-types": "^2.13.91",
     "@voiceflow/common": "^8.2.4",
     "@voiceflow/voice-types": "^2.9.70",
-    "@voiceflow/voiceflow-types": "^3.26.32",
+    "@voiceflow/voiceflow-types": "^3.26.32"
+  },
+  "devDependencies": {
     "googleapis": "92.0.0"
   },
   "files": [

--- a/packages/google-types/src/models.ts
+++ b/packages/google-types/src/models.ts
@@ -1,3 +1,3 @@
-import { oauth2_v2 } from 'googleapis/build/src/apis/oauth2/v2';
+import type { oauth2_v2 } from 'googleapis/build/src/apis/oauth2/v2';
 
 export interface GoogleProfile extends oauth2_v2.Schema$Userinfo {}


### PR DESCRIPTION
Looking in the realtime folder, googleapis is almost 100MB. That's kinda insane.

<img width="212" alt="Screenshot 2023-12-27 at 1 46 19 PM" src="https://github.com/voiceflow/libs/assets/5643574/bf26b3ba-4534-493f-9edb-f7fe2d9727f0">

We don't even use it in any meaningful way.