### PR TITLE
[Merged by Bors] - feat: added types for compiled cms variables (CV3-942)

### DIFF
--- a/packages/base-types/src/cms/variables.ts
+++ b/packages/base-types/src/cms/variables.ts
@@ -1,0 +1,27 @@
+export declare const VariableDatatype: {
+  readonly ANY: 'any';
+  readonly TEXT: 'text';
+  readonly DATE: 'date';
+  readonly IMAGE: 'image';
+  readonly NUMBER: 'number';
+  readonly BOOLEAN: 'boolean';
+};
+
+export type VariableDatatype = typeof VariableDatatype[keyof typeof VariableDatatype];
+
+export interface BaseCompiledCMSVariable {
+  isSystem: boolean;
+  defaultValue: string;
+}
+
+export interface CompiledSystemCMSVariable extends BaseCompiledCMSVariable {
+  isSystem: true;
+}
+
+export interface CompiledUserCMSVariable extends BaseCompiledCMSVariable {
+  isSystem: false;
+  datatype: VariableDatatype;
+  isArray: boolean;
+}
+
+export type CompiledCMSVariable = CompiledSystemCMSVariable | CompiledUserCMSVariable;

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -1,3 +1,4 @@
+import { CompiledCMSVariable } from '@base-types/cms/variables';
 import { AnyRecord, Nullable } from '@voiceflow/common';
 
 import { BaseCommand, Intent, PrototypeModel, Slot } from '../base';
@@ -45,6 +46,7 @@ export type SurveyContext<SurveyContextExtension extends AnyRecord = AnyRecord, 
   extraSlots: Slot[];
   extraIntents: Intent[];
   usedIntentsSet: string[];
+  cmsVariables: Record<string, CompiledCMSVariable>;
   /**
    * !TODO! - Make this required after migrating users to have `usedFunctionsMap`
    */

--- a/packages/base-types/src/models/version/prototype.ts
+++ b/packages/base-types/src/models/version/prototype.ts
@@ -46,7 +46,7 @@ export type SurveyContext<SurveyContextExtension extends AnyRecord = AnyRecord, 
   extraSlots: Slot[];
   extraIntents: Intent[];
   usedIntentsSet: string[];
-  cmsVariables: Record<string, CompiledCMSVariable>;
+  cmsVariables?: Record<string, CompiledCMSVariable>;
   /**
    * !TODO! - Make this required after migrating users to have `usedFunctionsMap`
    */


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CV3-942**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adds serialized `.cmsVariables` mapping to the surveyor context type. This is necessary to provide strict typing to 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Added `.cmsVariables` property to the surveyor context. Added additional typings for CMS variables to support this change. 

This change duplicates a similar change in `@voiceflow/dtos`. The changes in `@voiceflow/dtos` should be the canonical way of implementing the types, but the change was duplicated here to reduce the effort required to refactor the `general-runtime`. In the future, the `general-runtime` should be refactored to use `@voiceflow/dtos`.

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/general-runtime/pull/694
- https://github.com/voiceflow/general-service/pull/558
- https://github.com/voiceflow/libs/pull/501
- https://github.com/voiceflow/creator-app/pull/7761

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test