### PR TITLE
[Merged by Bors] - feat: add variable to store state for listen functionality(COR-1754)

### DIFF
--- a/packages/voiceflow-types/src/constants/variables.ts
+++ b/packages/voiceflow-types/src/constants/variables.ts
@@ -11,5 +11,5 @@ export enum BuiltInVariable {
   LAST_EVENT = 'last_event',
   VF_MEMORY = 'vf_memory',
   VF_CHUNKS = 'vf_chunks',
-  FUNCTION_QUEUED_MATCHES = 'function_queued_matches',
+  FUNCTION_CONDITIONAL_TRANSFERS = 'function_conditional_transfers',
 }

--- a/packages/voiceflow-types/src/constants/variables.ts
+++ b/packages/voiceflow-types/src/constants/variables.ts
@@ -11,4 +11,5 @@ export enum BuiltInVariable {
   LAST_EVENT = 'last_event',
   VF_MEMORY = 'vf_memory',
   VF_CHUNKS = 'vf_chunks',
+  FUNCTION_QUEUED_MATCHES = 'function_queued_matches',
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements COR-1754**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Added new built-in variable that will store state that describes what the Function step is listening for and what path it will follow in response. 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test