### PR TITLE
[Merged by Bors] - ci: update base for deletes (IN-946)

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -8,3 +8,4 @@ delete_merged_branches = true
 use_squash_merge = true
 cut_body_after = "### Implementation details. How do you make this change?"
 required_approvals=1
+update_base_for_deletes = true


### PR DESCRIPTION
Add a the bors `update_base_for_deletes` to not close the PRs of branches pointing to a branch being merged.
https://bors.tech/documentation/

> If turned on, and if delete_merged_branches is also turned on, then when a pull request is merged and its base branch is about to be deleted, any other pull requests made against the base branch will be fixed up.