### PR TITLE
[Merged by Bors] - feat: trace completion types (PL-909)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "workspaces": {
-    "packages": [
-      "packages/*"
-    ]
-  },
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "build": "turbo run build:cmd",
     "build:all": "yarn build",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "private": true,
   "workspaces": {
     "packages": [
-      "packages/*",
-      "meta/*"
+      "packages/*"
     ]
   },
   "scripts": {

--- a/packages/base-types/src/node/utils/trace.ts
+++ b/packages/base-types/src/node/utils/trace.ts
@@ -19,6 +19,9 @@ export enum TraceType {
   ENTITY_FILLING = 'entity-filling',
   CHANNEL_ACTION = 'channel-action',
   KNOWLEDGE_BASE = 'knowledgeBase',
+  COMPLETION_START = 'completion-start',
+  COMPLETION_CONTINUE = 'completion-continue',
+  COMPLETION_END = 'completion-end',
 }
 
 export interface BaseTraceFramePath<Event extends BaseEvent = BaseEvent> {

--- a/packages/base-types/src/trace/completion/completion-continue-trace.ts
+++ b/packages/base-types/src/trace/completion/completion-continue-trace.ts
@@ -1,0 +1,16 @@
+import { BaseTraceFrame, TraceType } from '@base-types/node/utils';
+
+export interface CompletionContinueTrace extends BaseTraceFrame<CompletionContinueTracePayload> {
+  type: TraceType.COMPLETION_CONTINUE;
+}
+
+export interface CompletionContinueTracePayload {
+  completion: string;
+  tokens?: {
+    answer: number;
+    query: number;
+    total: number;
+  };
+}
+
+export const isCompletionContinueTrace = (trace: BaseTraceFrame): trace is CompletionContinueTrace => trace.type === TraceType.COMPLETION_CONTINUE;

--- a/packages/base-types/src/trace/completion/completion-continue-trace.ts
+++ b/packages/base-types/src/trace/completion/completion-continue-trace.ts
@@ -1,4 +1,5 @@
-import { BaseTraceFrame, TraceType } from '@base-types/node/utils';
+import type { BaseTraceFrame } from '@base-types/node/utils';
+import { TraceType } from '@base-types/node/utils';
 
 export interface CompletionContinueTrace extends BaseTraceFrame<CompletionContinueTracePayload> {
   type: TraceType.COMPLETION_CONTINUE;
@@ -13,4 +14,5 @@ export interface CompletionContinueTracePayload {
   };
 }
 
-export const isCompletionContinueTrace = (trace: BaseTraceFrame): trace is CompletionContinueTrace => trace.type === TraceType.COMPLETION_CONTINUE;
+export const isCompletionContinueTrace = (trace: BaseTraceFrame): trace is CompletionContinueTrace =>
+  trace.type === TraceType.COMPLETION_CONTINUE;

--- a/packages/base-types/src/trace/completion/completion-end-trace.ts
+++ b/packages/base-types/src/trace/completion/completion-end-trace.ts
@@ -1,7 +1,9 @@
-import { BaseTraceFrame, TraceType } from '@base-types/node/utils';
+import type { BaseTraceFrame } from '@base-types/node/utils';
+import { TraceType } from '@base-types/node/utils';
 
 export interface CompletionEndTrace extends BaseTraceFrame {
   type: TraceType.COMPLETION_END;
 }
 
-export const isCompletionEndTrace = (trace: BaseTraceFrame): trace is CompletionEndTrace => trace.type === TraceType.COMPLETION_END;
+export const isCompletionEndTrace = (trace: BaseTraceFrame): trace is CompletionEndTrace =>
+  trace.type === TraceType.COMPLETION_END;

--- a/packages/base-types/src/trace/completion/completion-end-trace.ts
+++ b/packages/base-types/src/trace/completion/completion-end-trace.ts
@@ -1,0 +1,7 @@
+import { BaseTraceFrame, TraceType } from '@base-types/node/utils';
+
+export interface CompletionEndTrace extends BaseTraceFrame {
+  type: TraceType.COMPLETION_END;
+}
+
+export const isCompletionEndTrace = (trace: BaseTraceFrame): trace is CompletionEndTrace => trace.type === TraceType.COMPLETION_END;

--- a/packages/base-types/src/trace/completion/completion-start-trace.ts
+++ b/packages/base-types/src/trace/completion/completion-start-trace.ts
@@ -25,7 +25,7 @@ export interface CompletionStartTraceTextPayload extends BaseCompletionStartTrac
 }
 
 export interface BaseCompletionStartTracePayload {
-  type: string;
+  type: TraceType.TEXT | TraceType.SPEAK;
   completion: string;
   tokens?: {
     model: string;

--- a/packages/base-types/src/trace/completion/completion-start-trace.ts
+++ b/packages/base-types/src/trace/completion/completion-start-trace.ts
@@ -1,4 +1,5 @@
-import { BaseTraceFrame, TraceType } from '@base-types/node/utils';
+import type { BaseTraceFrame } from '@base-types/node/utils';
+import { TraceType } from '@base-types/node/utils';
 
 export interface CompletionStartTrace extends BaseTraceFrame<BaseCompletionStartTracePayload> {
   type: TraceType.COMPLETION_START;
@@ -35,9 +36,11 @@ export interface BaseCompletionStartTracePayload {
   };
 }
 
-export const isCompletionStartTrace = (trace: BaseTraceFrame): trace is CompletionStartTrace => trace.type === TraceType.COMPLETION_START;
+export const isCompletionStartTrace = (trace: BaseTraceFrame): trace is CompletionStartTrace =>
+  trace.type === TraceType.COMPLETION_START;
 
 export const isCompletionStartTraceSpeak = (trace: CompletionStartTrace): trace is CompletionStartTraceSpeak =>
   trace.payload.type === TraceType.SPEAK;
 
-export const isCompletionStartTraceText = (trace: CompletionStartTrace): trace is CompletionStartTraceText => trace.payload.type === TraceType.TEXT;
+export const isCompletionStartTraceText = (trace: CompletionStartTrace): trace is CompletionStartTraceText =>
+  trace.payload.type === TraceType.TEXT;

--- a/packages/base-types/src/trace/completion/completion-start-trace.ts
+++ b/packages/base-types/src/trace/completion/completion-start-trace.ts
@@ -1,0 +1,43 @@
+import { BaseTraceFrame, TraceType } from '@base-types/node/utils';
+
+export interface CompletionStartTrace extends BaseTraceFrame<BaseCompletionStartTracePayload> {
+  type: TraceType.COMPLETION_START;
+}
+
+export interface CompletionStartTraceSpeak extends CompletionStartTrace {
+  payload: CompletionStartTraceSpeakPayload;
+}
+
+export interface CompletionStartTraceText extends CompletionStartTrace {
+  payload: CompletionStartTraceTextPayload;
+}
+
+export type CompletionStartTracePayload = CompletionStartTraceSpeakPayload | CompletionStartTraceTextPayload;
+
+export interface CompletionStartTraceSpeakPayload extends BaseCompletionStartTracePayload {
+  type: TraceType.SPEAK;
+  voice?: string;
+}
+
+export interface CompletionStartTraceTextPayload extends BaseCompletionStartTracePayload {
+  type: TraceType.TEXT;
+  delay?: number;
+}
+
+export interface BaseCompletionStartTracePayload {
+  type: string;
+  completion: string;
+  tokens?: {
+    model: string;
+    answer: number;
+    query: number;
+    total: number;
+  };
+}
+
+export const isCompletionStartTrace = (trace: BaseTraceFrame): trace is CompletionStartTrace => trace.type === TraceType.COMPLETION_START;
+
+export const isCompletionStartTraceSpeak = (trace: CompletionStartTrace): trace is CompletionStartTraceSpeak =>
+  trace.payload.type === TraceType.SPEAK;
+
+export const isCompletionStartTraceText = (trace: CompletionStartTrace): trace is CompletionStartTraceText => trace.payload.type === TraceType.TEXT;

--- a/packages/base-types/src/trace/completion/index.ts
+++ b/packages/base-types/src/trace/completion/index.ts
@@ -1,0 +1,3 @@
+export * from './completion-continue-trace';
+export * from './completion-end-trace';
+export * from './completion-start-trace';

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -105,6 +105,27 @@ export interface ChannelActionTrace extends BaseTraceFrame<ChannelActionTracePay
   type: TraceType.CHANNEL_ACTION;
 }
 
+export interface CompletionStartTrace
+  extends BaseTraceFrame<{
+    type: TraceType.SPEAK | TraceType.TEXT;
+    completion: string;
+    voice?: string;
+    delay?: number;
+  }> {
+  type: TraceType.COMPLETION_START;
+}
+
+export interface CompletionContinueTrace
+  extends BaseTraceFrame<{
+    completion: string;
+  }> {
+  type: TraceType.COMPLETION_CONTINUE;
+}
+
+export interface CompletionEndTrace extends BaseTraceFrame {
+  type: TraceType.COMPLETION_END;
+}
+
 export type AnyTrace =
   | LogTrace
   | ExitTrace
@@ -121,4 +142,7 @@ export type AnyTrace =
   | CarouselTrace
   | CardV2Trace
   | EntityFillingTrace
-  | ChannelActionTrace;
+  | ChannelActionTrace
+  | CompletionStartTrace
+  | CompletionContinueTrace
+  | CompletionEndTrace;

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -12,6 +12,9 @@ import type { IntentRequest } from '@base-types/request';
 import type { Log as RuntimeLog } from '@base-types/runtimeLogs';
 import type { AnyRecord } from '@voiceflow/common';
 
+import { CompletionContinueTrace, CompletionEndTrace, CompletionStartTrace } from './completion';
+
+export { CompletionContinueTrace, CompletionEndTrace, CompletionStartTrace, CompletionStartTraceSpeak, CompletionStartTraceText } from './completion';
 export { TraceFrame as CardV2 } from '@base-types/node/cardV2';
 export { TraceFrame as Carousel } from '@base-types/node/carousel';
 export { TraceFrame as End } from '@base-types/node/exit';
@@ -103,38 +106,6 @@ export interface ChannelActionTracePayload {
 
 export interface ChannelActionTrace extends BaseTraceFrame<ChannelActionTracePayload> {
   type: TraceType.CHANNEL_ACTION;
-}
-
-export interface CompletionStartTrace
-  extends BaseTraceFrame<{
-    type: TraceType.SPEAK | TraceType.TEXT;
-    completion: string;
-    voice?: string;
-    delay?: number;
-    tokens?: {
-      model: string;
-      answer: number;
-      query: number;
-      total: number;
-    };
-  }> {
-  type: TraceType.COMPLETION_START;
-}
-
-export interface CompletionContinueTrace
-  extends BaseTraceFrame<{
-    completion: string;
-    tokens?: {
-      answer: number;
-      query: number;
-      total: number;
-    };
-  }> {
-  type: TraceType.COMPLETION_CONTINUE;
-}
-
-export interface CompletionEndTrace extends BaseTraceFrame {
-  type: TraceType.COMPLETION_END;
 }
 
 export type AnyTrace =

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -12,9 +12,15 @@ import type { IntentRequest } from '@base-types/request';
 import type { Log as RuntimeLog } from '@base-types/runtimeLogs';
 import type { AnyRecord } from '@voiceflow/common';
 
-import { CompletionContinueTrace, CompletionEndTrace, CompletionStartTrace } from './completion';
+import type { CompletionContinueTrace, CompletionEndTrace, CompletionStartTrace } from './completion';
 
-export { CompletionContinueTrace, CompletionEndTrace, CompletionStartTrace, CompletionStartTraceSpeak, CompletionStartTraceText } from './completion';
+export {
+  CompletionContinueTrace,
+  CompletionEndTrace,
+  CompletionStartTrace,
+  CompletionStartTraceSpeak,
+  CompletionStartTraceText,
+} from './completion';
 export { TraceFrame as CardV2 } from '@base-types/node/cardV2';
 export { TraceFrame as Carousel } from '@base-types/node/carousel';
 export { TraceFrame as End } from '@base-types/node/exit';

--- a/packages/base-types/src/trace/index.ts
+++ b/packages/base-types/src/trace/index.ts
@@ -111,6 +111,12 @@ export interface CompletionStartTrace
     completion: string;
     voice?: string;
     delay?: number;
+    tokens?: {
+      model: string;
+      answer: number;
+      query: number;
+      total: number;
+    };
   }> {
   type: TraceType.COMPLETION_START;
 }
@@ -118,6 +124,11 @@ export interface CompletionStartTrace
 export interface CompletionContinueTrace
   extends BaseTraceFrame<{
     completion: string;
+    tokens?: {
+      answer: number;
+      query: number;
+      total: number;
+    };
   }> {
   type: TraceType.COMPLETION_CONTINUE;
 }


### PR DESCRIPTION
Introduce completion trace types for use in LLM responses.
The start trace will indicate which type of trace should be used, as well as any additional metadata it needs (voice for speak, delay for text).
The end trace signals it is done.