### PR TITLE
fix: use latest orb version (IN-000)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
 setup: true
 
 orbs:
-  vfcommon: voiceflow/common@0.48.0
+  vfcommon: voiceflow/common@0.69.0
   gomplate: xavientois/gomplate@0.2.0
 
 workflows:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* IN-000

### Brief description. What is this change?

* Use latest ORB version to generate config.This allows for correct change detection when merging code from master to 
   prod branch hence allowing correct new images to be built 

### Checklist

- [x] ORB changes work on other mono-repos 