### PR TITLE
[Merged by Bors] - feat: added modelID to PrototypeModel in base-types (RUN-26)

### DIFF
--- a/packages/base-types/src/models/base/prototype.ts
+++ b/packages/base-types/src/models/base/prototype.ts
@@ -4,4 +4,5 @@ import type { Slot } from './slot';
 export interface PrototypeModel {
   slots: Slot[];
   intents: Intent[];
+  ragNLUId?: string;
 }

--- a/packages/base-types/src/models/base/prototype.ts
+++ b/packages/base-types/src/models/base/prototype.ts
@@ -4,5 +4,5 @@ import type { Slot } from './slot';
 export interface PrototypeModel {
   slots: Slot[];
   intents: Intent[];
-  ragNLUId?: string;
+  modelID?: string;
 }


### PR DESCRIPTION
### Brief description. What is this change?

Adds model ID to the PrototypeModel spec so general-runtime can access it when pulling a Version object. The ID is optional, and prototype is listed as a generic object for schema validation, so no updates to the ORM should be necessary.

This successfully builds and all tests pass.

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [*] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)