### PR TITLE
[Merged by Bors] - feat: global no reply enabled property (COR-4158)

### DIFF
--- a/packages/base-types/src/version/settings.ts
+++ b/packages/base-types/src/version/settings.ts
@@ -45,6 +45,7 @@ export interface Settings<Prompt = unknown> {
   globalNoReply?: {
     prompt?: Nullable<Prompt> | undefined;
     delay?: number | undefined;
+    enabled?: boolean;
   };
 
   globalNoMatch?:
@@ -69,7 +70,7 @@ export const defaultSettings = <Prompt>({
   defaultCarouselLayout = null,
 
   globalNoMatch = { type: GlobalNoMatchType.STATIC, prompt: undefined },
-  globalNoReply = { delay: undefined, prompt: undefined },
+  globalNoReply = { delay: undefined, prompt: undefined, enabled: true },
 
   deepgramASR,
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements COR-4158**

### Brief description. What is this change?
- Introduce enabled property to global no reply. Based on this flag, we can strip the noReply config in the compiler. To support existing projects, we can check strictly if value is `false`. 
