### PR TITLE
[Merged by Bors] - feat: fix message role type (RUN-447)

### DIFF
--- a/packages/base-types/src/utils/ai.ts
+++ b/packages/base-types/src/utils/ai.ts
@@ -56,13 +56,16 @@ export interface AIKnowledgeParams {
   source?: DATA_SOURCE;
 }
 
-export enum Role {
-  SYSTEM = 'system',
-  ASSISTANT = 'assistant',
-  USER = 'user',
-}
+// internal voiceflow message roles, roughly maps to OpenAI
+export const AIMessageRole = {
+  USER: 'user',
+  SYSTEM: 'system',
+  ASSISTANT: 'assistant',
+} as const;
+
+export type AIMessageRole = (typeof AIMessageRole)[keyof typeof AIMessageRole];
 
 export interface Message {
-  role: Role;
+  role: AIMessageRole;
   content: string;
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements RUN-447**

### Brief description. What is this change?

During deleting basic-types from dtos `AIMessageRole` was used, this introduced problems in runtime.