### PR TITLE
[Merged by Bors] - feat: globalNoReply.enabled false as default (COR-4232)

### DIFF
--- a/packages/base-types/src/version/settings.ts
+++ b/packages/base-types/src/version/settings.ts
@@ -70,7 +70,7 @@ export const defaultSettings = <Prompt>({
   defaultCarouselLayout = null,
 
   globalNoMatch = { type: GlobalNoMatchType.STATIC, prompt: undefined },
-  globalNoReply = { delay: undefined, prompt: undefined, enabled: true },
+  globalNoReply = { delay: undefined, prompt: undefined, enabled: false },
 
   deepgramASR,
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements COR-4232**
 - Enabled should be false by default, since prompt and delay are undefined. This will also enable a better UX, since we can set a default no reply message in the UI once user enables it.

