### PR TITLE
[Merged by Bors] - fix: ensure phrase is a string (COR-10013)

### DIFF
--- a/packages/common/src/utils/variables.ts
+++ b/packages/common/src/utils/variables.ts
@@ -84,7 +84,9 @@ export function replaceVariables(
     keepTypeIfOnlyVariable = false,
   }: { modifier?: ((variable: unknown) => unknown) | undefined; trim?: boolean; keepTypeIfOnlyVariable?: boolean } = {}
 ): string | unknown {
-  const formattedPhrase = trim ? phrase?.trim() : phrase;
+  const stringPhrase = typeof phrase === 'string' ? phrase : String(phrase ?? '');
+
+  const formattedPhrase = trim ? stringPhrase.trim() : stringPhrase;
 
   if (!formattedPhrase) {
     return '';

--- a/packages/common/src/utils/variables.ts
+++ b/packages/common/src/utils/variables.ts
@@ -85,8 +85,7 @@ export function replaceVariables(
   }: { modifier?: ((variable: unknown) => unknown) | undefined; trim?: boolean; keepTypeIfOnlyVariable?: boolean } = {}
 ): string | unknown {
   const stringPhrase = typeof phrase === 'string' ? phrase : String(phrase ?? '');
-
-  const formattedPhrase = trim ? stringPhrase.trim() : stringPhrase;
+  const formattedPhrase = trim ? stringPhrase.trim() : phrase;
 
   if (!formattedPhrase) {
     return '';


### PR DESCRIPTION
### TL;DR

Fix variable replacement to handle non-string inputs by converting them to strings.

### What changed?

Modified the `replaceVariables` function to explicitly convert non-string inputs to strings before processing. Previously, the function would attempt to trim potentially non-string values, which was rarely but occasionally resulting in a `phrase?.trim is not a function` error. Now, the function safely converts the input to a string first, handling all type issues.

### How to test?

1. Call `replaceVariables` with different types of inputs:
   - String values
   - Numbers
   - Undefined values
   - Null values
   - Objects
2. Verify that the function correctly converts all inputs to strings without errors
3. Ensure that variable replacement still works as expected with the converted strings

### Why make this change?

This change improves the robustness of the `replaceVariables` function by ensuring it can safely handle any type of input. Previously, calling methods like `trim()` on non-string values could cause runtime errors. This fix ensures consistent behavior regardless of input type, preventing potential crashes when the function receives unexpected data types.